### PR TITLE
bank-vaults: fix the usage of some common flags

### DIFF
--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -247,9 +247,7 @@ func stringInSlice(list []string, match string) bool {
 }
 
 func init() {
-	configBoolVar(configureCmd, cfgOnce, false, "Run configure only once")
 	configBoolVar(configureCmd, cfgFatal, false, "Make configuration errors fatal to the configurator")
-	configDurationVar(configureCmd, cfgUnsealPeriod, time.Second*5, "How often to attempt to unseal the Vault instance")
 	configStringSliceVar(configureCmd, cfgVaultConfigFile, []string{internalVault.DefaultConfigFile}, "The filename of the YAML/JSON Vault configuration")
 	configBoolVar(configureCmd, cfgDisableMetrics, false, "Disable configurer metrics")
 

--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -110,6 +110,11 @@ const (
 
 const cfgFilePath = "file-path"
 
+const (
+	cfgUnsealPeriod = "unseal-period"
+	cfgOnce         = "once"
+)
+
 // We need to pre-create a value and bind the the flag to this until
 // https://github.com/spf13/viper/issues/608 gets fixed.
 var k8sSecretLabels map[string]string
@@ -262,6 +267,10 @@ func init() {
 
 	// File flags
 	configStringVar(rootCmd, cfgFilePath, "", "The path prefix of the files where to store values in")
+
+	// Misc common flags
+	configBoolVar(rootCmd, cfgOnce, false, "Run configure/unsela only once")
+	configDurationVar(configureCmd, cfgUnsealPeriod, time.Second*5, "How often to attempt to unseal the Vault instance")
 }
 
 func main() {

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -26,9 +26,7 @@ import (
 )
 
 const (
-	cfgUnsealPeriod      = "unseal-period"
 	cfgInit              = "init"
-	cfgOnce              = "once"
 	cfgAuto              = "auto"
 	cfgRaft              = "raft"
 	cfgRaftLeaderAddress = "raft-leader-address"
@@ -194,9 +192,7 @@ func exitIfNecessary(unsealConfig unsealCfg, code int) {
 }
 
 func init() {
-	configDurationVar(unsealCmd, cfgUnsealPeriod, time.Second*5, "How often to attempt to unseal the vault instance")
 	configBoolVar(unsealCmd, cfgInit, false, "Initialize vault instance if not yet initialized")
-	configBoolVar(unsealCmd, cfgOnce, false, "Run unseal only once")
 	configBoolVar(unsealCmd, cfgRaft, false, "Join leader vault instance in raft mode")
 	configStringVar(unsealCmd, cfgRaftLeaderAddress, "", "Address of leader vault instance in raft mode")
 	configBoolVar(unsealCmd, cfgRaftSecondary, false, "This instance should always join a raft leader")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #1403
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Common CLI flags shouldn't bind more than one time.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Otherwise step on our own toe.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
