### PR TITLE
vault-operator: add support for specifying security context

### DIFF
--- a/charts/vault-operator/README.md
+++ b/charts/vault-operator/README.md
@@ -69,22 +69,24 @@ helm upgrade --install vault-operator banzaicloud-stable/charts/vault-operator
 
 The following table lists the configurable parameters of the vault chart and their default values.
 
-| Parameter                    | Description                                  | Default                      |
-| ---------------------------- | -------------------------------------------- | ---------------------------- |
-| `image.pullPolicy`           | Container pull policy                        | `IfNotPresent`               |
-| `image.repository`           | Container image to use                       | `banzaicloud/vault-operator` |
-| `image.bankVaultsRepository` | Container image to use for Bank-Vaults       | `banzaicloud/bank-vaults`    |
-| `image.tag`                  | Container image tag to deploy operator in    | `.Chart.AppVersion`          |
-| `image.bankVaultsTag`        | Container image tag to deploy bank-vaults in | `.Chart.AppVersion`          |
-| `image.imagePullSecrets`     | Image pull secrets for private repositories  | `[]`                         |
-| `replicaCount`               | k8s replicas                                 | `1`                          |
-| `resources.requests.cpu`     | Container requested CPU                      | `100m`                       |
-| `resources.requests.memory`  | Container requested memory                   | `128Mi`                      |
-| `resources.limits.cpu`       | Container CPU limit                          | `100m`                       |
-| `resources.limits.memory`    | Container memory limit                       | `256Mi`                      |
-| `crdAnnotations`             | Annotations for the Vault CRD                | `{}`                         |
-| `psp.enabled`                | Deploy PSP resources                         | `false`                      |
-| `psp.vaultSA`                | Used service account for vault               | `vault`                      |
+| Parameter                    | Description                                              | Default                      |
+| ---------------------------- | -------------------------------------------------------- | ---------------------------- |
+| `image.pullPolicy`           | Container pull policy                                    | `IfNotPresent`               |
+| `image.repository`           | Container image to use                                   | `banzaicloud/vault-operator` |
+| `image.bankVaultsRepository` | Container image to use for Bank-Vaults                   | `banzaicloud/bank-vaults`    |
+| `image.tag`                  | Container image tag to deploy operator in                | `.Chart.AppVersion`          |
+| `image.bankVaultsTag`        | Container image tag to deploy bank-vaults in             | `.Chart.AppVersion`          |
+| `image.imagePullSecrets`     | Image pull secrets for private repositories              | `[]`                         |
+| `replicaCount`               | k8s replicas                                             | `1`                          |
+| `resources.requests.cpu`     | Container requested CPU                                  | `100m`                       |
+| `resources.requests.memory`  | Container requested memory                               | `128Mi`                      |
+| `resources.limits.cpu`       | Container CPU limit                                      | `100m`                       |
+| `resources.limits.memory`    | Container memory limit                                   | `256Mi`                      |
+| `crdAnnotations`             | Annotations for the Vault CRD                            | `{}`                         |
+| `securityContext`            | Container security context for vault-operator deployment | `{}`                         |
+| `podSecurityContext`         | Pod security context for vault-operator deployment       | `{}`                         |
+| `psp.enabled`                | Deploy PSP resources                                     | `false`                      |
+| `psp.vaultSA`                | Used service account for vault                           | `vault`                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
           ports:
           - containerPort: {{ .Values.service.internalPort }}
           - containerPort: 8383
+          {{- if .Values.securityContext }}
+          securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: "/"
@@ -80,6 +84,10 @@ spec:
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
 {{- end }}
       serviceAccountName: {{ include "vault-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | yes
| Deprecations?   | yes
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?

Adds securityContext support for the operator helm chart

### Why?

This is needed for us to pass our security checks

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

