### PR TITLE
Migration to PSP to Built-in Pod Security in Vault-Secrets-Webhook

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.18.3
+version: 1.18.4
 appVersion: 1.18.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/webhook-psp.yaml
+++ b/charts/vault-secrets-webhook/templates/webhook-psp.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.rbac.psp.enabled }}
+{{- if .Values.rbac.psp.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 {{- if semverCompare ">=1.16-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
 apiVersion: policy/v1beta1
 {{- else  }}
 apiVersion: extensions/v1beta1
-{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "vault-secrets-webhook.fullname" . }}
@@ -34,7 +33,9 @@ spec:
   - secret
   - emptyDir
   - configMap
+{{- end }}
 ---
+{{- if .Values.rbac.psp.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 {{- if semverCompare ">=1.16-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
 apiVersion: policy/v1beta1
 {{- else  }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -88,8 +88,20 @@ metrics:
 securityContext:
   runAsUser: 65534
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
-podSecurityContext: {}
+podSecurity: ["pod-security.kubernetes.io/audit=restricted",
+      "pod-security.kubernetes.io/audit-version=latest",
+      "pod-security.kubernetes.io/warn=restricted",
+      "pod-security.kubernetes.io/warn-version=latest",
+      "pod-security.kubernetes.io/enforce=restricted",
+      "pod-security.kubernetes.io/enforce-version=v1.24"]
+
+podSecurityContext: 
+  fsGroup: 999
+  supplementalGroups:
+    - 999
+
 
 volumes: []
 # - name: vault-tls


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Remove PSP and migrate to PSA

- remove PSP since it's going to be removed in v1.25 in static yaml deployment.
- for Helm, If policy/v1beta1 API exists (k8s < 1.25), PSP will still be deployed using psp.enabled value (enabled by default).
- add restricted pod security standards for audit/warn/enforce

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

- remove PSP since it's going to be removed in v1.25 in static yaml deployment.
- for Helm, If policy/v1beta1 API exists (k8s < 1.25), PSP will still be deployed using psp.enabled value (enabled by default).
- add restricted pod security standards for audit/warn/enforce

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [X] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

