### PR TITLE
Secret syncer basics

### DIFF
--- a/charts/vault-secrets-webhook/Chart.yaml
+++ b/charts/vault-secrets-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: vault-secrets-webhook
-version: 1.19.0
+version: 1.19.1
 appVersion: 1.19.0
 description: A Helm chart that deploys a mutating admission webhook that configures applications to request secrets from Vault
 icon: https://raw.githubusercontent.com/banzaicloud/bank-vaults/main/docs/images/logo/bank-vaults-logo.svg

--- a/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
+++ b/charts/vault-secrets-webhook/templates/apiservice-webhook.yaml
@@ -365,3 +365,64 @@ webhooks:
   sideEffects: {{ .Values.apiSideEffectValue }}
 {{- end }}
 {{- end }}
+{{- if .Values.deploymentSecretSync }}
+- name: sync.{{ template "vault-secrets-webhook.name" . }}.admission.banzaicloud.com
+  {{- if semverCompare ">=1.14-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
+  admissionReviewVersions: ["v1beta1"]
+  {{- if .Values.timeoutSeconds }}
+  timeoutSeconds: {{ .Values.timeoutSeconds }}
+  {{- end }}
+  {{- end }}
+  clientConfig:
+    {{- if .Values.webhookClientConfig.useUrl }}
+    url: {{ .Values.webhookClientConfig.url }}
+    {{- else }}
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ template "vault-secrets-webhook.fullname" . }}
+      path: /deployment-secret-sync
+    {{- end }}
+    caBundle: {{ $caCrt }}
+  rules:
+  - operations:
+      - CREATE
+      - UPDATE
+    apiGroups:
+      - "*"
+    apiVersions:
+      - "*"
+    resources:
+      - deployments
+  failurePolicy: {{ .Values.customResourcesFailurePolicy }}
+  namespaceSelector:
+  {{- if $crNamespaceSelector.matchLabels }}
+    matchLabels:
+{{ toYaml $crNamespaceSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+    {{- if $crNamespaceSelector.matchExpressions }}
+{{ toYaml $crNamespaceSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
+{{- if semverCompare ">=1.15-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
+  objectSelector:
+  {{- if $crObjectSelector.matchLabels }}
+    matchLabels:
+{{ toYaml $crObjectSelector.matchLabels | indent 6 }}
+  {{- end }}
+    matchExpressions:
+    {{- if $crObjectSelector.matchExpressions }}
+{{ toYaml $crObjectSelector.matchExpressions | indent 4 }}
+    {{- end }}
+    - key: security.banzaicloud.io/mutate
+      operator: NotIn
+      values:
+      - skip
+{{- end }}
+{{- if semverCompare ">=1.12-0" (include "vault-secrets-webhook.capabilities.kubeVersion" .) }}
+  sideEffects: {{ .Values.apiSideEffectValue }}
+{{- end }}
+{{- end }}

--- a/charts/vault-secrets-webhook/values.yaml
+++ b/charts/vault-secrets-webhook/values.yaml
@@ -141,6 +141,9 @@ deployment:
   # Strategy for the deployment
   strategy: {}
 
+# Enable automatic Vault secret synchronization on deployments
+deploymentSecretSync: false
+
 # A list of Kubernetes resource types to mutate as well:
 # Example: ["ingresses", "servicemonitors"]
 customResourceMutations: []

--- a/cmd/vault-secrets-syncer/cmd/deploy.go
+++ b/cmd/vault-secrets-syncer/cmd/deploy.go
@@ -1,0 +1,65 @@
+// Copyright © 2023 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// deployCmd represents the deploy command
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Sync secrets of a deployment",
+	//	Long: `A longer description that spans multiple lines and likely contains examples
+	// and usage of using your command. For example:
+	//
+	// Cobra is a CLI library for Go that empowers applications.
+	// This application is a tool to generate the needed files
+	// to quickly create a Cobra application.`,
+	Run: syncDeployment,
+}
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+}
+
+func syncDeployment(cmd *cobra.Command, args []string) {
+	var logger *logrus.Entry
+	{
+		l := logrus.New()
+		l.SetLevel(logrus.DebugLevel)
+		logger = l.WithField("app", "vault-secrets-syncer")
+	}
+
+	if len(args) != 1 {
+		logger.Errorln("You must specify one argument")
+		os.Exit(1)
+	}
+
+	logger.Error("Syncing secrets from deployment failed")
+	os.Exit(1)
+}

--- a/cmd/vault-secrets-syncer/cmd/deploy.go
+++ b/cmd/vault-secrets-syncer/cmd/deploy.go
@@ -103,6 +103,10 @@ func syncDeployment(cmd *cobra.Command, args []string) {
 	}
 	logger.Debug("Collecting secrets from envs done")
 
+	// 2. Collect secrets from vault.security.banzaicloud.io/vault-env-from-path annnotation
+	collector.CollectSecretsFromAnnotation(deployment, vaultSecrets)
+	logger.Debug("Collecting secrets from annotations done")
+
 	logger.Error("Syncing secrets from deployment failed")
 	os.Exit(1)
 }

--- a/cmd/vault-secrets-syncer/cmd/deploy.go
+++ b/cmd/vault-secrets-syncer/cmd/deploy.go
@@ -141,6 +141,43 @@ func syncDeployment(cmd *cobra.Command, args []string) {
 	}
 	logger.Debugf("vaultSecrets: %+v", vaultSecrets)
 
+	// Hashing the secrets
+	hashStr, err := collector.CreateCollectedVaultSecretsHash(vaultSecrets)
+	if err != nil {
+		logger.Errorln(err)
+		os.Exit(1)
+	}
+	logger.Debugf("Hashed vaultSecrets: %s", hashStr)
+
+	// Set the hash as an annotation on the deployment if it is different from the current once
+	secretVersionHash := deployment.Spec.Template.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"]
+	if secretVersionHash != "" {
+		if secretVersionHash == hashStr {
+			logger.Infof("Secrets are up to date")
+			os.Exit(0)
+		} else {
+			logger.Infof("Secrets are out of date")
+			deployment.Spec.Template.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"] = hashStr
+			_, err := k8sClient.AppsV1().Deployments(deployment.Namespace).Update(context.Background(), deployment, metav1.UpdateOptions{})
+			if err != nil {
+				logger.Errorln(err)
+				os.Exit(1)
+			}
+			logger.Infof("Secret version hash updated")
+			os.Exit(0)
+		}
+	} else {
+		logger.Infof("Setting secret version hash")
+		deployment.Spec.Template.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"] = hashStr
+		_, err := k8sClient.AppsV1().Deployments(deployment.Namespace).Update(context.Background(), deployment, metav1.UpdateOptions{})
+		if err != nil {
+			logger.Errorln(err)
+			os.Exit(1)
+		}
+		logger.Infof("Secret version hash set")
+		os.Exit(0)
+	}
+
 	logger.Error("Syncing secrets from deployment failed")
 	os.Exit(1)
 }

--- a/cmd/vault-secrets-syncer/cmd/deploy.go
+++ b/cmd/vault-secrets-syncer/cmd/deploy.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"os"
 
+	"github.com/bank-vaults/vault-sdk/vault"
 	"github.com/banzaicloud/bank-vaults/internal/collector"
-	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"

--- a/cmd/vault-secrets-syncer/cmd/deploy.go
+++ b/cmd/vault-secrets-syncer/cmd/deploy.go
@@ -108,6 +108,14 @@ func syncDeployment(cmd *cobra.Command, args []string) {
 	collector.CollectSecretsFromAnnotation(deployment, vaultSecrets)
 	logger.Debug("Collecting secrets from annotations done")
 
+	// 3. Collect secrets from Consul templates
+	err = collector.CollectSecretsFromTemplates(k8sClient, deployment, vaultSecrets)
+	if err != nil {
+		logger.Errorln(err)
+		os.Exit(1)
+	}
+	logger.Debug("Collecting secrets from templates done")
+
 	if len(vaultSecrets) == 0 {
 		logger.Infof("No secrets found for deployment %s.%s", deployment.Namespace, deployment.Name)
 		os.Exit(0)

--- a/cmd/vault-secrets-syncer/cmd/root.go
+++ b/cmd/vault-secrets-syncer/cmd/root.go
@@ -1,0 +1,53 @@
+// Copyright © 2023 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "vault-secrets-syncer",
+	Short: "Temporary CLI tool to detect and sync secret changes",
+	// Long: ``,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) {},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.vault-secrets-syncer.yaml)")
+	rootCmd.PersistentFlags().StringP("namespace", "n", "default", "Namespace of the resource, default is 'default'")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/vault-secrets-syncer/main.go
+++ b/cmd/vault-secrets-syncer/main.go
@@ -1,0 +1,21 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/banzaicloud/bank-vaults/cmd/vault-secrets-syncer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/cmd/vault-secrets-webhook/main.go
+++ b/cmd/vault-secrets-webhook/main.go
@@ -111,7 +111,6 @@ func main() {
 	whLogger := whlog.NewLogrus(logger)
 
 	mutator := webhook.ErrorLoggerMutator(mutatingWebhook.VaultSecretsMutator, whLogger)
-	syncMutator := webhook.ErrorLoggerMutator(mutatingWebhook.VaultSecretSyncMutator, whLogger)
 
 	promRegistry := prometheus.NewRegistry()
 	metricsRecorder, err := whmetrics.NewRecorder(whmetrics.RecorderConfig{Registry: promRegistry})
@@ -124,7 +123,7 @@ func main() {
 	secretHandler := handlerFor(mutating.WebhookConfig{ID: "vault-secrets-secret", Obj: &corev1.Secret{}, Logger: whLogger, Mutator: mutator}, metricsRecorder)
 	configMapHandler := handlerFor(mutating.WebhookConfig{ID: "vault-secrets-configmap", Obj: &corev1.ConfigMap{}, Logger: whLogger, Mutator: mutator}, metricsRecorder)
 	objectHandler := handlerFor(mutating.WebhookConfig{ID: "vault-secrets-object", Obj: &unstructured.Unstructured{}, Logger: whLogger, Mutator: mutator}, metricsRecorder)
-	deploymentSyncHandler := handlerFor(mutating.WebhookConfig{ID: "vault-secrets-deployment-sync", Obj: &appsv1.Deployment{}, Logger: whLogger, Mutator: syncMutator}, metricsRecorder)
+	deploymentSyncHandler := handlerFor(mutating.WebhookConfig{ID: "vault-secrets-deployment-sync", Obj: &appsv1.Deployment{}, Logger: whLogger, Mutator: mutator}, metricsRecorder)
 
 	mux := http.NewServeMux()
 	mux.Handle("/pods", podHandler)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -165,3 +165,12 @@ func getSecret(k8sClient kubernetes.Interface, secretName string, ns string) (*c
 	}
 	return secret, nil
 }
+
+func CollectSecretsFromAnnotation(deployment *appsv1.Deployment, vaultSecrets map[string]int) {
+	vaultEnvFromPathSecret := deployment.Spec.Template.GetAnnotations()["vault.security.banzaicloud.io/vault-env-from-path"]
+	if vaultEnvFromPathSecret != "" {
+		if _, ok := vaultSecrets[vaultEnvFromPathSecret]; !ok {
+			vaultSecrets[vaultEnvFromPathSecret] = 0
+		}
+	}
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -21,6 +21,7 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"regexp"
 	"sort"
@@ -32,15 +33,22 @@ import (
 	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
-func CollectDeploymentSecretsFromEnv(
+func CollectDeploymentEnvVars(
+	k8sClient kubernetes.Interface,
 	deployment *appsv1.Deployment,
-	vaultSecrets map[string]int,
-) error {
+) (
+	[]corev1.EnvVar,
+	map[metav1.Object][]corev1.EnvVar,
+	error,
+) {
 	var envVars []corev1.EnvVar
+	objectEnvVars := make(map[metav1.Object][]corev1.EnvVar)
 
 	// Collect containers and initContainers from the deployment
 	var containers []corev1.Container
@@ -49,14 +57,138 @@ func CollectDeploymentSecretsFromEnv(
 
 	// Iterate through all containers and initContainers in the deployment
 	for _, container := range containers {
-		// List of environment variables to set in the container.
+		// Look for Vault secret references in secrets and configmaps linked as EnvFrom
+		if len(container.EnvFrom) > 0 {
+			for _, env := range container.EnvFrom {
+				if env.ConfigMapRef != nil {
+					configMap, err := getConfigmap(k8sClient, env.ConfigMapRef.Name, deployment.Namespace)
+					if err != nil {
+						if apierrors.IsNotFound(err) || (env.ConfigMapRef.Optional != nil && *env.ConfigMapRef.Optional) {
+							continue
+						}
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get EnvFrom configmap", "configmap", env.ConfigMapRef.Name)
+					}
+					for name, value := range configMap.Data {
+						appendEnvVar(&envVars, objectEnvVars, configMap, name, value)
+					}
+
+					// Look for Vault secret references in last applied configuration
+					lastAppliedConfigMap, err := getConfigmapFromLastAppliedConfiguration(configMap)
+					if err != nil {
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get EnvFrom configmap from last applied configuration", "configmap", env.ConfigMapRef.Name)
+					}
+					for name, value := range lastAppliedConfigMap.Data {
+						appendEnvVar(&envVars, objectEnvVars, configMap, name, value)
+					}
+				}
+				if env.SecretRef != nil {
+					secret, err := getSecret(k8sClient, env.SecretRef.Name, deployment.Namespace)
+					if err != nil {
+						if apierrors.IsNotFound(err) || (env.SecretRef.Optional != nil && *env.SecretRef.Optional) {
+							continue
+						}
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get EnvFrom secret", "secret", env.SecretRef.Name)
+					}
+					for name, value := range secret.Data {
+						appendEnvVar(&envVars, objectEnvVars, secret, name, string(value))
+					}
+
+					// Look for Vault secret references in last applied configuration
+					lastAppliedSecret, err := getSecretFromLastAppliedConfiguration(secret)
+					if err != nil {
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get EnvFrom secret from last applied configuration", "secret", env.SecretRef.Name)
+					}
+					for name, value := range lastAppliedSecret.Data {
+						appendEnvVar(&envVars, objectEnvVars, secret, name, string(value))
+					}
+				}
+			}
+		}
+
+		// Look for Vault secret references in container envs
 		for _, env := range container.Env {
 			if HasVaultPrefix(env.Value) || HasInlineVaultDelimiters(env.Value) {
 				envVars = append(envVars, env)
 			}
+			// Look for Vault secret references in secrets and configmaps linked as ValueFrom in container envs
+			if env.ValueFrom != nil {
+				if env.ValueFrom.ConfigMapKeyRef != nil {
+					configMap, err := getConfigmap(k8sClient, env.ValueFrom.ConfigMapKeyRef.Name, deployment.Namespace)
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							continue
+						}
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get ValueFrom configmap", "configmap", env.ValueFrom.ConfigMapKeyRef.Name)
+					}
+
+					value := configMap.Data[env.ValueFrom.ConfigMapKeyRef.Key]
+					appendEnvVar(&envVars, objectEnvVars, configMap, env.Name, value)
+
+					// Look for Vault secret references in last applied configuration as well
+					lastAppliedConfigMap, err := getConfigmapFromLastAppliedConfiguration(configMap)
+					if err != nil {
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get ValueFrom configmap from last applied configuration", "configmap", env.ValueFrom.ConfigMapKeyRef.Name)
+					}
+					value = lastAppliedConfigMap.Data[env.ValueFrom.ConfigMapKeyRef.Key]
+					appendEnvVar(&envVars, objectEnvVars, configMap, env.Name, value)
+				}
+				if env.ValueFrom.SecretKeyRef != nil {
+					secret, err := getSecret(k8sClient, env.ValueFrom.SecretKeyRef.Name, deployment.Namespace)
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							continue
+						}
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get ValueFrom secret", "secret", env.ValueFrom.SecretKeyRef.Name)
+					}
+
+					// Return either the value from the secret or the value from the last applied configuration
+					value := secret.Data[env.ValueFrom.SecretKeyRef.Key]
+					appendEnvVar(&envVars, objectEnvVars, secret, env.Name, string(value))
+
+					// Look for Vault secret references in last applied configuration as well
+					lastAppliedSecret, err := getSecretFromLastAppliedConfiguration(secret)
+					if err != nil {
+						return nil, nil, errors.WrapIfWithDetails(err, "failed to get ValueFrom secret from last applied configuration", "secret", env.ValueFrom.SecretKeyRef.Name)
+					}
+
+					value = lastAppliedSecret.Data[env.ValueFrom.SecretKeyRef.Key]
+					appendEnvVar(&envVars, objectEnvVars, secret, env.Name, string(value))
+				}
+			}
 		}
 	}
+	return envVars, objectEnvVars, nil
+}
 
+func CollectSecretEnvVars(secret *corev1.Secret) ([]corev1.EnvVar, error) {
+	var envVars []corev1.EnvVar
+	for name, value := range secret.Data {
+		if HasVaultPrefix(string(value)) || HasInlineVaultDelimiters(string(value)) {
+			envVar := corev1.EnvVar{
+				Name:  name,
+				Value: string(value),
+			}
+			envVars = append(envVars, envVar)
+		}
+	}
+	return envVars, nil
+}
+
+func CollectConfigMapEnvVars(configmap *corev1.ConfigMap) ([]corev1.EnvVar, error) {
+	var envVars []corev1.EnvVar
+	for name, value := range configmap.Data {
+		if HasVaultPrefix(value) || HasInlineVaultDelimiters(value) {
+			envVar := corev1.EnvVar{
+				Name:  name,
+				Value: value,
+			}
+			envVars = append(envVars, envVar)
+		}
+	}
+	return envVars, nil
+}
+
+func CollectSecretsFromEnvVars(envVars []corev1.EnvVar, vaultSecrets map[string]int) {
 	// Iterate through all environment variables and extract secrets
 	secretRegexp := regexp.MustCompile(`vault:(.*?)#`)
 	for _, envVar := range envVars {
@@ -73,8 +205,6 @@ func CollectDeploymentSecretsFromEnv(
 			}
 		}
 	}
-
-	return nil
 }
 
 func CollectSecretsFromAnnotation(deployment *appsv1.Deployment, vaultSecrets map[string]int) {
@@ -188,4 +318,70 @@ func CreateCollectedVaultSecretsHash(vaultSecrets map[string]int) (string, error
 	h := sha256.Sum256(data)
 	// Convert hash to hex string
 	return hex.EncodeToString(h[:]), nil
+}
+
+func SetAnnotationToConfigMaps(
+	k8sClient kubernetes.Interface,
+	vaultClient *vault.Client,
+	configMaps map[string][]corev1.EnvVar,
+	namespace string,
+) error {
+	for configMapName, envVars := range configMaps {
+		configMapVaultSecrets := make(map[string]int)
+		CollectSecretsFromEnvVars(envVars, configMapVaultSecrets)
+
+		for secretName := range configMapVaultSecrets {
+			currentVersion, err := GetSecretVersionFromVault(vaultClient, secretName)
+			if err != nil {
+				return errors.Wrap(err, "failed to get secret version from vault")
+			}
+			configMapVaultSecrets[secretName] = currentVersion
+		}
+
+		// Create hash from the secrets
+		hashStr, err := CreateCollectedVaultSecretsHash(configMapVaultSecrets)
+		if err != nil {
+			return errors.Wrap(err, "failed to create hash from secrets")
+		}
+
+		// Set the hash as an annotation on the deployent
+		_, err = k8sClient.CoreV1().ConfigMaps(namespace).Patch(context.Background(), configMapName, types.MergePatchType, []byte(fmt.Sprintf(`{"metadata":{"annotations":{"alpha.vault.security.banzaicloud.io/secret-version-hash":"%s"}}}`, hashStr)), metav1.PatchOptions{})
+		if err != nil {
+			return errors.Wrap(err, "failed to set annotation to configmap")
+		}
+	}
+	return nil
+}
+
+func SetAnnotationToSecrets(
+	k8sClient kubernetes.Interface,
+	vaultClient *vault.Client,
+	secrets map[string][]corev1.EnvVar,
+	namespace string,
+) error {
+	for secretName, envVars := range secrets {
+		secretVaultSecrets := make(map[string]int)
+		CollectSecretsFromEnvVars(envVars, secretVaultSecrets)
+
+		for secretName := range secretVaultSecrets {
+			currentVersion, err := GetSecretVersionFromVault(vaultClient, secretName)
+			if err != nil {
+				return errors.Wrap(err, "failed to get secret version from vault")
+			}
+			secretVaultSecrets[secretName] = currentVersion
+		}
+
+		// Create hash from the secrets
+		hashStr, err := CreateCollectedVaultSecretsHash(secretVaultSecrets)
+		if err != nil {
+			return errors.Wrap(err, "failed to create hash from secrets")
+		}
+
+		// Set the hash as an annotation on the deployent
+		_, err = k8sClient.CoreV1().Secrets(namespace).Patch(context.Background(), secretName, types.MergePatchType, []byte(fmt.Sprintf(`{"metadata":{"annotations":{"alpha.vault.security.banzaicloud.io/secret-version-hash":"%s"}}}`, hashStr)), metav1.PatchOptions{})
+		if err != nil {
+			return errors.Wrap(err, "failed to set annotation to secret")
+		}
+	}
+	return nil
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -30,7 +30,7 @@ import (
 	"text/template"
 
 	"emperror.dev/errors"
-	"github.com/banzaicloud/bank-vaults/pkg/sdk/vault"
+	"github.com/bank-vaults/vault-sdk/vault"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,0 +1,123 @@
+// Copyright © 2023 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func getConfigmap(k8sClient kubernetes.Interface, cmName string, ns string) (*corev1.ConfigMap, error) {
+	configMap, err := k8sClient.CoreV1().ConfigMaps(ns).Get(context.Background(), cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return configMap, nil
+}
+
+func getSecret(k8sClient kubernetes.Interface, secretName string, ns string) (*corev1.Secret, error) {
+	secret, err := k8sClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func LookForEnvFrom(k8sClient kubernetes.Interface, envFrom []corev1.EnvFromSource, ns string) ([]corev1.EnvVar, error) {
+	var envVars []corev1.EnvVar
+
+	for _, env := range envFrom {
+		if env.ConfigMapRef != nil {
+			configmap, err := getConfigmap(k8sClient, env.ConfigMapRef.Name, ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) || (env.ConfigMapRef.Optional != nil && *env.ConfigMapRef.Optional) {
+					continue
+				}
+				return envVars, err
+			}
+			for key, value := range configmap.Data {
+				if HasVaultPrefix(value) || HasInlineVaultDelimiters(value) {
+					envFromCM := corev1.EnvVar{
+						Name:  key,
+						Value: value,
+					}
+					envVars = append(envVars, envFromCM)
+				}
+			}
+		}
+		if env.SecretRef != nil {
+			secret, err := getSecret(k8sClient, env.SecretRef.Name, ns)
+			if err != nil {
+				if apierrors.IsNotFound(err) || (env.SecretRef.Optional != nil && *env.SecretRef.Optional) {
+					continue
+				}
+				return envVars, err
+			}
+			for name, v := range secret.Data {
+				value := string(v)
+				if HasVaultPrefix(value) || HasInlineVaultDelimiters(value) {
+					envFromSec := corev1.EnvVar{
+						Name:  name,
+						Value: value,
+					}
+					envVars = append(envVars, envFromSec)
+				}
+			}
+		}
+	}
+	return envVars, nil
+}
+
+func LookForValueFrom(k8sClient kubernetes.Interface, env corev1.EnvVar, ns string) (*corev1.EnvVar, error) {
+	if env.ValueFrom.ConfigMapKeyRef != nil {
+		configmap, err := getConfigmap(k8sClient, env.ValueFrom.ConfigMapKeyRef.Name, ns)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		value := configmap.Data[env.ValueFrom.ConfigMapKeyRef.Key]
+		if HasVaultPrefix(value) || HasInlineVaultDelimiters(value) {
+			fromCM := corev1.EnvVar{
+				Name:  env.Name,
+				Value: value,
+			}
+			return &fromCM, nil
+		}
+	}
+	if env.ValueFrom.SecretKeyRef != nil {
+		secret, err := getSecret(k8sClient, env.ValueFrom.SecretKeyRef.Name, ns)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		value := string(secret.Data[env.ValueFrom.SecretKeyRef.Key])
+		if HasVaultPrefix(value) || HasInlineVaultDelimiters(value) {
+			fromSecret := corev1.EnvVar{
+				Name:  env.Name,
+				Value: value,
+			}
+			return &fromSecret, nil
+		}
+	}
+	return nil, nil
+}

--- a/internal/collector/common.go
+++ b/internal/collector/common.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Banzai Cloud
+// Copyright © 2023 Banzai Cloud
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package webhook
+package collector
 
 import (
+	"regexp"
 	"strings"
 )
 
-func hasVaultPrefix(value string) bool {
+func HasVaultPrefix(value string) bool {
 	return strings.HasPrefix(value, "vault:") || strings.HasPrefix(value, ">>vault:")
+}
+
+var inlineMutationRegex = regexp.MustCompile(`\${([>]{0,2}vault:.*?#*}?)}`)
+
+func HasInlineVaultDelimiters(value string) bool {
+	return len(FindInlineVaultDelimiters(value)) > 0
+}
+
+func FindInlineVaultDelimiters(value string) [][]string {
+	return inlineMutationRegex.FindAllStringSubmatch(value, -1)
 }

--- a/internal/collector/common.go
+++ b/internal/collector/common.go
@@ -15,8 +15,14 @@
 package collector
 
 import (
+	"context"
+	"encoding/json"
 	"regexp"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func HasVaultPrefix(value string) bool {
@@ -31,4 +37,51 @@ func HasInlineVaultDelimiters(value string) bool {
 
 func FindInlineVaultDelimiters(value string) [][]string {
 	return inlineMutationRegex.FindAllStringSubmatch(value, -1)
+}
+
+func getConfigmap(k8sClient kubernetes.Interface, cmName string, ns string) (*corev1.ConfigMap, error) {
+	configMap, err := k8sClient.CoreV1().ConfigMaps(ns).Get(context.Background(), cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return configMap, nil
+}
+
+func getSecret(k8sClient kubernetes.Interface, secretName string, ns string) (*corev1.Secret, error) {
+	secret, err := k8sClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func getConfigmapFromLastAppliedConfiguration(configmap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	var lastAppliedConfigMap corev1.ConfigMap
+	err := json.Unmarshal([]byte(configmap.ObjectMeta.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]), &lastAppliedConfigMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lastAppliedConfigMap, nil
+}
+
+func getSecretFromLastAppliedConfiguration(secret *corev1.Secret) (*corev1.Secret, error) {
+	var lastAppliedSecret corev1.Secret
+	err := json.Unmarshal([]byte(secret.ObjectMeta.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]), &lastAppliedSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lastAppliedSecret, nil
+}
+
+func appendEnvVar(envVars *[]corev1.EnvVar, mapWithEnvVars map[metav1.Object][]corev1.EnvVar, object metav1.Object, varName, varValue string) {
+	if HasVaultPrefix(varValue) || HasInlineVaultDelimiters(varValue) {
+		envVar := corev1.EnvVar{
+			Name:  varName,
+			Value: varValue,
+		}
+		*envVars = append(*envVars, envVar)
+		mapWithEnvVars[object] = append(mapWithEnvVars[object], envVar)
+	}
 }

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -85,6 +85,7 @@ type VaultConfig struct {
 	VaultServiceAccount           string
 	ObjectNamespace               string
 	MutateProbes                  bool
+	SecretSync                    bool
 	Token                         string
 }
 
@@ -429,6 +430,12 @@ func parseVaultConfig(obj metav1.Object, ar *model.AdmissionReview) VaultConfig 
 		vaultConfig.TransitBatchSize = int(batchSize)
 	} else {
 		vaultConfig.TransitBatchSize = viper.GetInt("transit_batch_size")
+	}
+
+	if val, ok := annotations["alpha.vault.security.banzaicloud.io/reload-on-secret-change"]; ok {
+		vaultConfig.SecretSync, _ = strconv.ParseBool(val)
+	} else {
+		vaultConfig.SecretSync = false
 	}
 
 	vaultConfig.Token = viper.GetString("vault_token")

--- a/pkg/webhook/configmap.go
+++ b/pkg/webhook/configmap.go
@@ -52,6 +52,13 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 
 	defer vaultClient.Close()
 
+	if vaultConfig.SecretSync {
+		err := mw.SyncConfigMap(configMap, vaultClient)
+		if err != nil {
+			return errors.Wrap(err, "setting secret hash for configmap sync failed")
+		}
+	}
+
 	config := injector.Config{
 		TransitKeyID:     vaultConfig.TransitKeyID,
 		TransitPath:      vaultConfig.TransitPath,

--- a/pkg/webhook/configmap.go
+++ b/pkg/webhook/configmap.go
@@ -20,17 +20,18 @@ import (
 	"emperror.dev/errors"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/banzaicloud/bank-vaults/internal/collector"
 	"github.com/banzaicloud/bank-vaults/internal/injector"
 )
 
 func configMapNeedsMutation(configMap *corev1.ConfigMap) bool {
 	for _, value := range configMap.Data {
-		if hasVaultPrefix(value) || injector.HasInlineVaultDelimiters(value) {
+		if collector.HasVaultPrefix(value) || collector.HasInlineVaultDelimiters(value) {
 			return true
 		}
 	}
 	for _, value := range configMap.BinaryData {
-		if hasVaultPrefix(string(value)) {
+		if collector.HasVaultPrefix(string(value)) {
 			return true
 		}
 	}
@@ -64,7 +65,7 @@ func (mw *MutatingWebhook) MutateConfigMap(configMap *corev1.ConfigMap, vaultCon
 	}
 
 	for key, value := range configMap.BinaryData {
-		if hasVaultPrefix(string(value)) {
+		if collector.HasVaultPrefix(string(value)) {
 			binaryData := map[string]string{
 				key: string(value),
 			}

--- a/pkg/webhook/object.go
+++ b/pkg/webhook/object.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/banzaicloud/bank-vaults/internal/injector"
+	"github.com/banzaicloud/bank-vaults/internal/collector"
 )
 
 type element interface {
@@ -89,16 +90,16 @@ func traverseObject(o interface{}, secretInjector injector.SecretInjector) error
 	for e := range iterator {
 		switch s := e.Get().(type) {
 		case string:
-			if hasVaultPrefix(s) {
+			if collector.HasVaultPrefix(s) {
 				dataFromVault, err := secretInjector.GetDataFromVault(map[string]string{"data": s})
 				if err != nil {
 					return err
 				}
 
 				e.Set(dataFromVault["data"])
-			} else if injector.HasInlineVaultDelimiters(s) {
+			} else if collector.HasInlineVaultDelimiters(s) {
 				dataFromVault := s
-				for _, vaultSecretReference := range injector.FindInlineVaultDelimiters(s) {
+				for _, vaultSecretReference := range collector.FindInlineVaultDelimiters(s) {
 					mapData, err := secretInjector.GetDataFromVault(map[string]string{"data": vaultSecretReference[1]})
 					if err != nil {
 						return err

--- a/pkg/webhook/pod.go
+++ b/pkg/webhook/pod.go
@@ -239,7 +239,7 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 	for i, container := range containers {
 		var envVars []corev1.EnvVar
 		if len(container.EnvFrom) > 0 {
-			envFrom, err := collector.LookForEnvFrom(mw.k8sClient, container.EnvFrom, vaultConfig.ObjectNamespace)
+			envFrom, err := mw.lookForEnvFrom(container.EnvFrom, vaultConfig.ObjectNamespace)
 			if err != nil {
 				return false, err
 			}
@@ -251,7 +251,7 @@ func (mw *MutatingWebhook) mutateContainers(ctx context.Context, containers []co
 				envVars = append(envVars, env)
 			}
 			if env.ValueFrom != nil {
-				valueFrom, err := collector.LookForValueFrom(mw.k8sClient, env, vaultConfig.ObjectNamespace)
+				valueFrom, err := mw.lookForValueFrom(env, vaultConfig.ObjectNamespace)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -99,6 +99,13 @@ func (mw *MutatingWebhook) MutateSecret(secret *corev1.Secret, vaultConfig Vault
 
 	defer vaultClient.Close()
 
+	if vaultConfig.SecretSync {
+		err := mw.SyncSecret(secret, vaultClient)
+		if err != nil {
+			return errors.Wrap(err, "setting secret hash for secret sync failed")
+		}
+	}
+
 	config := injector.Config{
 		TransitKeyID:     vaultConfig.TransitKeyID,
 		TransitPath:      vaultConfig.TransitPath,

--- a/pkg/webhook/secret.go
+++ b/pkg/webhook/secret.go
@@ -23,6 +23,7 @@ import (
 	"emperror.dev/errors"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/banzaicloud/bank-vaults/internal/collector"
 	"github.com/banzaicloud/bank-vaults/internal/injector"
 )
 
@@ -67,13 +68,13 @@ func secretNeedsMutation(secret *corev1.Secret) (bool, error) {
 				}
 
 				auth := string(authBytes)
-				if hasVaultPrefix(auth) {
+				if collector.HasVaultPrefix(auth) {
 					return true, nil
 				}
 			}
-		} else if hasVaultPrefix(string(value)) {
+		} else if collector.HasVaultPrefix(string(value)) {
 			return true, nil
-		} else if injector.HasInlineVaultDelimiters(string(value)) {
+		} else if collector.HasInlineVaultDelimiters(string(value)) {
 			return true, nil
 		}
 	}
@@ -135,7 +136,7 @@ func (mw *MutatingWebhook) mutateDockerCreds(secret *corev1.Secret, dc *dockerCr
 		}
 
 		auth := string(authBytes)
-		if hasVaultPrefix(auth) {
+		if collector.HasVaultPrefix(auth) {
 			split := strings.Split(auth, ":")
 			if len(split) != 4 {
 				return errors.New("splitting auth credentials failed")

--- a/pkg/webhook/sync.go
+++ b/pkg/webhook/sync.go
@@ -76,5 +76,16 @@ func (mw *MutatingWebhook) SyncDeployment(deployment *appsv1.Deployment, vaultCo
 		vaultSecrets[secretName] = currentVersion
 	}
 
+	// Create hash from the secrets
+	hashStr, err := collector.CreateCollectedVaultSecretsHash(vaultSecrets)
+	if err != nil {
+		return errors.Wrap(err, "failed to create hash from secrets")
+	}
+	mw.logger.Debugf("Hash from collected secrets with updated versions from Vault: %s", hashStr)
+
+	// Set the hash as an annotation on the deployent
+	deployment.Spec.Template.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"] = hashStr
+
+	mw.logger.Debugf("Collect secrets from deployment: %s.%s done", deployment.GetNamespace(), deployment.GetName())
 	return nil
 }

--- a/pkg/webhook/sync.go
+++ b/pkg/webhook/sync.go
@@ -15,46 +15,31 @@
 package webhook
 
 import (
-	"context"
-
 	"emperror.dev/errors"
+	"github.com/bank-vaults/vault-sdk/vault"
 	"github.com/banzaicloud/bank-vaults/internal/collector"
-	"github.com/slok/kubewebhook/v2/pkg/model"
-	"github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func (mw *MutatingWebhook) VaultSecretSyncMutator(ctx context.Context, ar *model.AdmissionReview, obj metav1.Object) (*mutating.MutatorResult, error) {
-	vaultConfig := parseVaultConfig(obj, ar)
-
-	if vaultConfig.Skip {
-		return &mutating.MutatorResult{}, nil
-	}
-
-	if !vaultConfig.SecretSync {
-		return &mutating.MutatorResult{}, nil
-	}
-
-	switch v := obj.(type) {
-	case *appsv1.Deployment:
-		return &mutating.MutatorResult{MutatedObject: v}, mw.SyncDeployment(v, vaultConfig)
-
-	default:
-		return &mutating.MutatorResult{}, nil
-	}
-}
-
 func (mw *MutatingWebhook) SyncDeployment(deployment *appsv1.Deployment, vaultConfig VaultConfig) error {
+	// Early exit if secret sync is not enabled
+	if !vaultConfig.SecretSync {
+		return nil
+	}
+
 	mw.logger.Debugf("Collecting secrets from deployment: %s.%s...", deployment.GetNamespace(), deployment.GetName())
 
 	vaultSecrets := make(map[string]int)
 
 	// 1. Collect environment variables that need to be injected from Vault
-	err := collector.CollectDeploymentSecretsFromEnv(deployment, vaultSecrets)
+	envVars, _, err := collector.CollectDeploymentEnvVars(mw.k8sClient, deployment)
 	if err != nil {
 		return errors.Wrap(err, "failed to collect secrets from envs")
 	}
+	mw.logger.Debug("Collecting env vars from envs done")
+
+	collector.CollectSecretsFromEnvVars(envVars, vaultSecrets)
 	mw.logger.Debug("Collecting secrets from envs done")
 
 	// 2. Collect secrets from vault.security.banzaicloud.io/vault-env-from-path annnotation
@@ -94,5 +79,79 @@ func (mw *MutatingWebhook) SyncDeployment(deployment *appsv1.Deployment, vaultCo
 	deployment.Spec.Template.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"] = hashStr
 
 	mw.logger.Debugf("Collect secrets from deployment: %s.%s done", deployment.GetNamespace(), deployment.GetName())
+	return nil
+}
+
+func (mw *MutatingWebhook) SyncSecret(secret *corev1.Secret, vaultClient *vault.Client) error {
+	mw.logger.Debugf("Collecting secrets from secret: %s.%s...", secret.GetNamespace(), secret.GetName())
+
+	vaultSecrets := make(map[string]int)
+
+	// Collect environment variables that need to be injected from Vault
+	envVars, err := collector.CollectSecretEnvVars(secret)
+	if err != nil {
+		return errors.Wrap(err, "failed to collect secrets from envs")
+	}
+	mw.logger.Debug("Collecting env vars from envs done")
+
+	collector.CollectSecretsFromEnvVars(envVars, vaultSecrets)
+	mw.logger.Debug("Collecting secrets from envs done")
+
+	for secretName := range vaultSecrets {
+		currentVersion, err := collector.GetSecretVersionFromVault(vaultClient, secretName)
+		if err != nil {
+			return errors.Wrap(err, "failed to get secret version from vault")
+		}
+		vaultSecrets[secretName] = currentVersion
+	}
+
+	// Create hash from the secrets
+	hashStr, err := collector.CreateCollectedVaultSecretsHash(vaultSecrets)
+	if err != nil {
+		return errors.Wrap(err, "failed to create hash from secrets")
+	}
+	mw.logger.Debugf("Hash from collected secrets with updated versions from Vault: %s", hashStr)
+
+	// Set the hash as an annotation on the deployent
+	secret.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"] = hashStr
+
+	mw.logger.Debugf("Collect secrets from deployment: %s.%s done", secret.GetNamespace(), secret.GetName())
+	return nil
+}
+
+func (mw *MutatingWebhook) SyncConfigMap(configMap *corev1.ConfigMap, vaultClient *vault.Client) error {
+	mw.logger.Debugf("Collecting secrets from configmap: %s.%s...", configMap.GetNamespace(), configMap.GetName())
+
+	vaultSecrets := make(map[string]int)
+
+	// Collect environment variables that need to be injected from Vault
+	envVars, err := collector.CollectConfigMapEnvVars(configMap)
+	if err != nil {
+		return errors.Wrap(err, "failed to collect secrets from envs")
+	}
+	mw.logger.Debug("Collecting env vars from envs done")
+
+	collector.CollectSecretsFromEnvVars(envVars, vaultSecrets)
+	mw.logger.Debug("Collecting secrets from envs done")
+
+	for secretName := range vaultSecrets {
+		currentVersion, err := collector.GetSecretVersionFromVault(vaultClient, secretName)
+		if err != nil {
+			return errors.Wrap(err, "failed to get secret version from vault")
+		}
+		vaultSecrets[secretName] = currentVersion
+	}
+
+	// Create hash from the secrets
+	hashStr, err := collector.CreateCollectedVaultSecretsHash(vaultSecrets)
+	if err != nil {
+		return errors.Wrap(err, "failed to create hash from secrets")
+	}
+	mw.logger.Debugf("Hash from collected secrets with updated versions from Vault: %s", hashStr)
+
+	// Set the hash as an annotation on the deployent
+	configMap.GetAnnotations()["alpha.vault.security.banzaicloud.io/secret-version-hash"] = hashStr
+
+	mw.logger.Debugf("Collect secrets from deployment: %s.%s done", configMap.GetNamespace(), configMap.GetName())
 	return nil
 }

--- a/pkg/webhook/sync.go
+++ b/pkg/webhook/sync.go
@@ -57,5 +57,9 @@ func (mw *MutatingWebhook) SyncDeployment(deployment *appsv1.Deployment, vaultCo
 	}
 	mw.logger.Debug("Collecting secrets from envs done")
 
+	// 2. Collect secrets from vault.security.banzaicloud.io/vault-env-from-path annnotation
+	collector.CollectSecretsFromAnnotation(deployment, vaultSecrets)
+	mw.logger.Debug("Collecting secrets from annotations done")
+
 	return nil
 }

--- a/pkg/webhook/sync.go
+++ b/pkg/webhook/sync.go
@@ -1,0 +1,49 @@
+// Copyright © 2023 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+
+	"github.com/slok/kubewebhook/v2/pkg/model"
+	"github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (mw *MutatingWebhook) VaultSecretSyncMutator(ctx context.Context, ar *model.AdmissionReview, obj metav1.Object) (*mutating.MutatorResult, error) {
+	vaultConfig := parseVaultConfig(obj, ar)
+
+	if vaultConfig.Skip {
+		return &mutating.MutatorResult{}, nil
+	}
+
+	if !vaultConfig.SecretSync {
+		return &mutating.MutatorResult{}, nil
+	}
+
+	switch v := obj.(type) {
+	case *appsv1.Deployment:
+		return &mutating.MutatorResult{MutatedObject: v}, mw.SyncDeployment(v, vaultConfig)
+
+	default:
+		return &mutating.MutatorResult{}, nil
+	}
+}
+
+func (mw *MutatingWebhook) SyncDeployment(deployment *appsv1.Deployment, vaultConfig VaultConfig) error {
+	mw.logger.Debugf("Collecting secrets from deployment: %s.%s...", deployment.GetNamespace(), deployment.GetName())
+	return nil
+}

--- a/pkg/webhook/sync.go
+++ b/pkg/webhook/sync.go
@@ -61,6 +61,13 @@ func (mw *MutatingWebhook) SyncDeployment(deployment *appsv1.Deployment, vaultCo
 	collector.CollectSecretsFromAnnotation(deployment, vaultSecrets)
 	mw.logger.Debug("Collecting secrets from annotations done")
 
+	// 3. Collect secrets from Consul templates
+	err = collector.CollectSecretsFromTemplates(mw.k8sClient, deployment, vaultSecrets)
+	if err != nil {
+		return errors.Wrap(err, "failed to collect secrets from templates")
+	}
+	mw.logger.Debug("Collecting secrets from templates done")
+
 	// Create a Vault client and get the current version of the secrets
 	vaultClient, err := mw.newVaultClient(vaultConfig)
 	if err != nil {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -28,6 +28,7 @@ import (
 	"github.com/slok/kubewebhook/v2/pkg/log"
 	"github.com/slok/kubewebhook/v2/pkg/model"
 	"github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
+	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -65,6 +66,9 @@ func (mw *MutatingWebhook) VaultSecretsMutator(ctx context.Context, ar *model.Ad
 
 	case *unstructured.Unstructured:
 		return &mutating.MutatorResult{MutatedObject: v}, mw.MutateObject(v, vaultConfig)
+
+	case *appsv1.Deployment:
+		return &mutating.MutatorResult{MutatedObject: v}, mw.SyncDeployment(v, vaultConfig)
 
 	default:
 		return &mutating.MutatorResult{}, nil

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -30,13 +30,10 @@ import (
 	"github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	logrusadapter "logur.dev/adapter/logrus"
-
-	"github.com/banzaicloud/bank-vaults/internal/injector"
 )
 
 type MutatingWebhook struct {
@@ -69,107 +66,6 @@ func (mw *MutatingWebhook) VaultSecretsMutator(ctx context.Context, ar *model.Ad
 	default:
 		return &mutating.MutatorResult{}, nil
 	}
-}
-
-func (mw *MutatingWebhook) getDataFromConfigmap(cmName string, ns string) (map[string]string, error) {
-	configMap, err := mw.k8sClient.CoreV1().ConfigMaps(ns).Get(context.Background(), cmName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return configMap.Data, nil
-}
-
-func (mw *MutatingWebhook) getDataFromSecret(secretName string, ns string) (map[string][]byte, error) {
-	secret, err := mw.k8sClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return secret.Data, nil
-}
-
-func (mw *MutatingWebhook) lookForEnvFrom(envFrom []corev1.EnvFromSource, ns string) ([]corev1.EnvVar, error) {
-	var envVars []corev1.EnvVar
-
-	for _, ef := range envFrom {
-		if ef.ConfigMapRef != nil {
-			data, err := mw.getDataFromConfigmap(ef.ConfigMapRef.Name, ns)
-			if err != nil {
-				if apierrors.IsNotFound(err) || (ef.ConfigMapRef.Optional != nil && *ef.ConfigMapRef.Optional) {
-					continue
-				} else {
-					return envVars, err
-				}
-			}
-			for key, value := range data {
-				if hasVaultPrefix(value) || injector.HasInlineVaultDelimiters(value) {
-					envFromCM := corev1.EnvVar{
-						Name:  key,
-						Value: value,
-					}
-					envVars = append(envVars, envFromCM)
-				}
-			}
-		}
-		if ef.SecretRef != nil {
-			data, err := mw.getDataFromSecret(ef.SecretRef.Name, ns)
-			if err != nil {
-				if apierrors.IsNotFound(err) || (ef.SecretRef.Optional != nil && *ef.SecretRef.Optional) {
-					continue
-				} else {
-					return envVars, err
-				}
-			}
-			for name, v := range data {
-				value := string(v)
-				if hasVaultPrefix(value) || injector.HasInlineVaultDelimiters(value) {
-					envFromSec := corev1.EnvVar{
-						Name:  name,
-						Value: value,
-					}
-					envVars = append(envVars, envFromSec)
-				}
-			}
-		}
-	}
-	return envVars, nil
-}
-
-func (mw *MutatingWebhook) lookForValueFrom(env corev1.EnvVar, ns string) (*corev1.EnvVar, error) {
-	if env.ValueFrom.ConfigMapKeyRef != nil {
-		data, err := mw.getDataFromConfigmap(env.ValueFrom.ConfigMapKeyRef.Name, ns)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		value := data[env.ValueFrom.ConfigMapKeyRef.Key]
-		if hasVaultPrefix(value) || injector.HasInlineVaultDelimiters(value) {
-			fromCM := corev1.EnvVar{
-				Name:  env.Name,
-				Value: value,
-			}
-			return &fromCM, nil
-		}
-	}
-	if env.ValueFrom.SecretKeyRef != nil {
-		data, err := mw.getDataFromSecret(env.ValueFrom.SecretKeyRef.Name, ns)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, err
-		}
-		value := string(data[env.ValueFrom.SecretKeyRef.Key])
-		if hasVaultPrefix(value) || injector.HasInlineVaultDelimiters(value) {
-			fromSecret := corev1.EnvVar{
-				Name:  env.Name,
-				Value: value,
-			}
-			return &fromSecret, nil
-		}
-	}
-	return nil, nil
 }
 
 func (mw *MutatingWebhook) newVaultClient(vaultConfig VaultConfig) (*vault.Client, error) {

--- a/test/deploy/test-deployment-sync.yaml
+++ b/test/deploy/test-deployment-sync.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sync-secrets
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+    vault.security.banzaicloud.io/vault-role: "default"
+    vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+    # vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-path: "kubernetes"
+type: Opaque
+data:
+  AWS_SECRET_ACCESS_KEY: dmF1bHQ6c2VjcmV0L2RhdGEvYWNjb3VudHMvYXdzI0FXU19TRUNSRVRfQUNDRVNTX0tFWQ==
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sync-configmap
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+    vault.security.banzaicloud.io/vault-role: "default"
+    vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+    # vault.security.banzaicloud.io/vault-skip-verify: "true"
+    vault.security.banzaicloud.io/vault-path: "kubernetes"
+data:
+  AWS_ACCESS_KEY_ID: vault:secret/data/accounts/aws#AWS_ACCESS_KEY_ID
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: my-app
+    my-app.kubernetes.io/name: my-app-vault-agent
+    branches: "true"
+  name: my-app-vault-agent
+  namespace: default
+data:
+  config.hcl: |
+    vault {
+      // This is needed until https://github.com/hashicorp/vault/issues/7889
+      // gets fixed, otherwise it is automated by the webhook.
+      ca_cert = "/vault/tls/ca.crt"
+    }
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "auth/kubernetes"
+        config = {
+          role = "default"
+        }
+      }
+      sink "file" {
+        config = {
+          path = "/vault/.vault-token"
+        }
+      }
+    }
+    template {
+      contents = <<EOH
+        {{- with secret "secret/mysql" }}
+        mysql_root_password: {{ .Data.data.MYSQL_ROOT_PASSWORD }}
+        {{ end }}
+      EOH
+      destination = "/vault/secrets/config.yaml"
+      command     = "/bin/sh -c \"kill -HUP $(pidof vault-demo-app) || true\""
+    }
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-secrets-sync
+  annotations:
+    vault.security.banzaicloud.io/vault-addr: "https://vault.default.svc.cluster.local:8200"
+    vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+    alpha.vault.security.banzaicloud.io/reload-on-secret-change: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello-secrets-sync
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello-secrets-sync
+      annotations:
+        vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+        vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+        vault.security.banzaicloud.io/vault-env-from-path: "secret/data/dockerrepo"
+        vault.security.banzaicloud.io/vault-agent-configmap: "my-app-vault-agent"
+    spec:
+      containers:
+        - name: alpine
+          image: alpine
+          command: ["sh", "-c", "echo AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID && echo AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY && echo MYSQL_PASSWORD: $MYSQL_PASSWORD && cat /vault/secrets/config.yaml && echo DOCKER_REPO_USER: $DOCKER_REPO_USER && echo going to sleep... && sleep 10000"]
+          env:
+            - name: MYSQL_PASSWORD
+              value: vault:secret/data/mysql#MYSQL_PASSWORD
+          #   - name: AWS_ACCESS_KEY_ID
+          #     valueFrom:
+          #       configMapKeyRef:
+          #         name: sync-configmap
+          #         key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sync-secrets
+                  key: AWS_SECRET_ACCESS_KEY
+          envFrom:
+          - configMapRef:
+              name: sync-configmap
+          # - secretRef:
+          #     name: sync-secrets

--- a/test/deploy/test-deployment-sync.yaml
+++ b/test/deploy/test-deployment-sync.yaml
@@ -8,6 +8,7 @@ metadata:
     vault.security.banzaicloud.io/vault-tls-secret: vault-tls
     # vault.security.banzaicloud.io/vault-skip-verify: "true"
     vault.security.banzaicloud.io/vault-path: "kubernetes"
+    alpha.vault.security.banzaicloud.io/reload-on-secret-change: "true"
 type: Opaque
 data:
   AWS_SECRET_ACCESS_KEY: dmF1bHQ6c2VjcmV0L2RhdGEvYWNjb3VudHMvYXdzI0FXU19TRUNSRVRfQUNDRVNTX0tFWQ==
@@ -24,6 +25,7 @@ metadata:
     vault.security.banzaicloud.io/vault-tls-secret: vault-tls
     # vault.security.banzaicloud.io/vault-skip-verify: "true"
     vault.security.banzaicloud.io/vault-path: "kubernetes"
+    alpha.vault.security.banzaicloud.io/reload-on-secret-change: "true"
 data:
   AWS_ACCESS_KEY_ID: vault:secret/data/accounts/aws#AWS_ACCESS_KEY_ID
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Implementing the basics for a new operator working together with the webhook, which - if enabled - will periodically check if the secrets used by a resource that has the `alpha.vault.security.banzaicloud.io/reload-on-secret-change` annotation set to `true` are still the same version as in Vault, and if not, updates the resource ensuring it has the the latest version of the secrets.

This feature will support only deployments first. Implemented in this PR:
- a new logic in the webhook that adds a new `alpha.vault.security.banzaicloud.io/secret-version-hash` annotation with the hashed value of the path and current version of the Vault secrets to the deployment
- a temporary CLI tool that accepts the name (and namespace) of a deployment, and collects the used Vault secrets again, generates the hash, compares it to the one in the annotation, and if they are not matching, updates the annotation which causes the pods to restart, and the webhook doing its job again, but now with the latest version of the secrets. The logic implemented here will be the part of an operator later.

The new `collector` package can find Vault secret paths to collect that are specified:
- as `env` in the pod template in the following format: `vault:secret/data/mysql#MYSQL_PASSWORD`
- in a secret or configmap through `valueFrom` or `envFrom` in the following format: `vault:secret/data/mysql#MYSQL_PASSWORD`. It also uses the contents of the `kubectl.kubernetes.io/last-applied-configuration` annotation, because if the secret or configmap mutation is also enabled in the webhook, the value of these Vault secrets already being injected into them so the original Vault secret path can only be found there. Also if the secret change affected a secret stored in a k8s secret or configmap, that also needs to be re-applied which achieved by patching them with the contents of the `last-applied-configuration` annotation.
- in the `vault.security.banzaicloud.io/vault-env-from-path` annotation in the pod template
- in vault templates from configmaps specified in the `vault.security.banzaicloud.io/vault-agent-configmap` annotation in the pod template

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To make the first steps towards a new operator that keeps resources mutated by the Bank-Vaults webhook up to date with Vault.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Steps for local testing:
1. Prepare a kubernetes cluster (recommended with Docker desktop or kind)
2. Start the operator with `make operator-up`
3. Create the namespace `vswh` (`kubectl create namespace vswh`)
4. Create a Vault instance with `kubectl apply -f operator/deploy/cr.yaml`
5. Build a local version of the webhook: `docker build . -t ghcr.io/banzaicloud/vault-secrets-webhook:local -f Dockerfile.webhook`
6. Install the webhook:
```
helm upgrade --install vault-secrets-webhook charts/vault-secrets-webhook \
    --set replicaCount=1 \
    --set image.tag=local \
    --set image.pullPolicy=IfNotPresent \
    --set configMapMutation=true \
    --set deploymentSecretSync=true \
    --set configmapFailurePolicy=Fail \
    --set podsFailurePolicy=Fail \
    --set secretsFailurePolicy=Fail \
    --set vaultEnv.tag=latest \
    --namespace vswh
```
7. Apply the test deployment: `kubectl apply -f test/deploy/test-deployment-sync.yaml`
8. Check if the annotation is present in the deployment: `kubectl get deploy hello-secrets-sync -o jsonpath='{ .metadata.annotations.alpha\.vault\.security\.banzaicloud\.io/secret-version-hash }'`
9. Start port-forwarding Vault: `kubectl port-forward vault-0 8200:8200` and in another terminal instance, export some important envs that the CLI tool needs:
```
export VAULT_TOKEN=$(kubectl get secrets vault-unseal-keys -o jsonpath={.data.vault-root} | base64 --decode)

kubectl get secret vault-tls -o jsonpath="{.data.ca\.crt}" | base64 --decode > $PWD/vault-ca.crt
export VAULT_CACERT=$PWD/vault-ca.crt

export VAULT_ADDR=https://127.0.0.1:8200
```
10. Run the CLI tool: `go run cmd/vault-secrets-syncer/main.go deploy hello-secrets-sync`. The last log should say `Secrets are up to date`
11. Now change a secret in Vault in the same terminal window: `vault kv patch secret/mysql MYSQL_PASSWORD=updated3xtr3ms3cr3t`
12. Run the CLI tool again and observe in its logs and also with `kubectl get deploy hello-secrets-sync -o jsonpath='{ .metadata.annotations.alpha\.vault\.security\.banzaicloud\.io/secret-version-hash }'` that the annotation is indeed has been changed and the pods restarted, and in the pod logs the new secret has been echoed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- ~User guide and development docs updated (if needed)~
- ~Related Helm chart(s) updated (if needed)~