### PR TITLE
chore: Use verified publisher image `hashicorp/vault`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,7 @@ jobs:
 
     services:
       vault:
-        image: vault:1.13.3
+        image: hashicorp/vault:1.13.3
         env:
           SKIP_SETCAP: true
           VAULT_DEV_ROOT_TOKEN_ID: 227e1cce-6bf7-30bb-2d2a-acc854318caf

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       vault:
-        image: vault:1.13.3
+        image: hashicorp/vault:1.13.3
         options: >-
           --name=vault
           --cap-add=IPC_LOCK


### PR DESCRIPTION
Fixes https://github.com/bank-vaults/bank-vaults/issues/2040

Hashicorp has deprecated Duplicative Docker Images (see https://developer.hashicorp.com/vault/docs/v1.13.x/deprecation).
New versions of vault are only published to https://hub.docker.com/hashicorp/vault.
https://hub.docker.com/_/vault only contains old versions up to 1.13.3.