### PR TITLE
Fix AWS KMS encryption context

### DIFF
--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -118,9 +118,12 @@ const (
 
 // We need to pre-create a value and bind the the flag to this until
 // https://github.com/spf13/viper/issues/608 gets fixed.
-var k8sSecretLabels map[string]string
+var (
+	k8sSecretLabels         map[string]string
+	awsKmsEncryptionContext map[string]string
+)
 
-var awsKmsEncryptionContext = map[string]string{
+var defaultAwsKmsEncryptionContext = map[string]string{
 	"Tool": "bank-vaults",
 }
 
@@ -170,9 +173,9 @@ func configStringSliceVar(cmd *cobra.Command, key string, defaultValue []string,
 	_ = c.BindPFlag(key, cmd.PersistentFlags().Lookup(key))
 }
 
-func configStringMapVar(cmd *cobra.Command, key string, value *map[string]string, description string) {
-	cmd.PersistentFlags().StringToStringVar(value, key, nil, description)
-	_ = c.BindPFlag(key, cmd.Flags().Lookup(key))
+func configStringMapVar(cmd *cobra.Command, key string, value *map[string]string, defaultValue map[string]string, description string) {
+	cmd.PersistentFlags().StringToStringVar(value, key, defaultValue, description)
+	_ = c.BindPFlag(key, cmd.PersistentFlags().Lookup(key))
 }
 
 func init() {
@@ -227,7 +230,7 @@ func init() {
 	// AWS KMS flags
 	configStringSliceVar(rootCmd, cfgAWSKMSRegion, nil, "The region of the AWS KMS key to encrypt values")
 	configStringSliceVar(rootCmd, cfgAWSKMSKeyID, nil, "The ID or ARN of the AWS KMS key to encrypt values")
-	configStringMapVar(rootCmd, cfgAWSKMSEncryptionContext, &awsKmsEncryptionContext, "The encryption context that AWS KMS will use to encrypt values")
+	configStringMapVar(rootCmd, cfgAWSKMSEncryptionContext, &awsKmsEncryptionContext, defaultAwsKmsEncryptionContext, "The encryption context that AWS KMS will use to encrypt values")
 
 	// AWS S3 Object Storage flags
 	configStringSliceVar(rootCmd, cfgAWSS3Region, []string{"us-east-1"}, "The region to use for storing values in AWS S3")
@@ -262,7 +265,7 @@ func init() {
 	// K8S Secret Storage flags
 	configStringVar(rootCmd, cfgK8SNamespace, "", "The namespace of the K8S Secret to store values in")
 	configStringVar(rootCmd, cfgK8SSecret, "", "The name of the K8S Secret to store values in")
-	configStringMapVar(rootCmd, cfgK8SLabels, &k8sSecretLabels, "The labels of the K8S Secret to store values in")
+	configStringMapVar(rootCmd, cfgK8SLabels, &k8sSecretLabels, map[string]string{}, "The labels of the K8S Secret to store values in")
 
 	// HSM flags
 	configStringVar(rootCmd, cfgHSMModulePath, "", "The library path of the HSM device")

--- a/pkg/kv/awskms/awskms.go
+++ b/pkg/kv/awskms/awskms.go
@@ -85,12 +85,10 @@ func (a *awsKMS) Get(key string) ([]byte, error) {
 
 func (a *awsKMS) encrypt(plainText []byte) ([]byte, error) {
 	out, err := a.kmsService.Encrypt(&kms.EncryptInput{
-		KeyId:     aws.String(a.kmsID),
-		Plaintext: plainText,
-		EncryptionContext: map[string]*string{
-			"Tool": aws.String("bank-vaults"),
-		},
-		GrantTokens: []*string{},
+		KeyId:             aws.String(a.kmsID),
+		Plaintext:         plainText,
+		EncryptionContext: a.encryptionContext,
+		GrantTokens:       []*string{},
 	})
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to encrypt with KMS client")


### PR DESCRIPTION
This PR fixes three bugs, two of which has been introduced in #1968:

- Fixes the default value for encryption context
- Fixes flags for map types
- Fixes AWS KMS encryption context for encryption