### PR TITLE
chore: Update to `hashicorp/vault:1.14.1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,7 @@ jobs:
 
     services:
       vault:
-        image: hashicorp/vault:1.14.0
+        image: hashicorp/vault:1.14.1
         env:
           SKIP_SETCAP: true
           VAULT_DEV_ROOT_TOKEN_ID: 227e1cce-6bf7-30bb-2d2a-acc854318caf

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       vault:
-        image: hashicorp/vault:1.14.0
+        image: hashicorp/vault:1.14.1
         options: >-
           --name=vault
           --cap-add=IPC_LOCK


### PR DESCRIPTION
Update to `hashicorp/vault:1.14.1` due to bug: https://github.com/hashicorp/vault/issues/21465