### PR TITLE
fix(licensei): add busl-1.1 to approved list

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -4,7 +4,8 @@ approved = [
   "bsd-3-clause",
   "bsd-2-clause",
   "mpl-2.0",
-  "isc"
+  "isc",
+  "busl-1.1"
 ]
 
 ignored = [
@@ -15,6 +16,7 @@ ignored = [
   "logur.dev/adapter/logrus", # MIT
   "logur.dev/logur", # MIT
   "emperror.dev/errors", # MIT
+  "github.com/hashicorp/vault/api", # BUSL-1.1
 
   # Unsupported VCS
   "gopkg.in/fsnotify.v1",


### PR DESCRIPTION
This new licence is what Hashicorp recently switched to.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #2121

## Notes for reviewer

<!-- Anything the reviewer should know? -->
