### PR TITLE
fix: Typos in errors, logs, vars, and comments

### DIFF
--- a/cmd/bank-vaults/configure.go
+++ b/cmd/bank-vaults/configure.go
@@ -163,8 +163,8 @@ var configureCmd = &cobra.Command{
 func handleConfigurationError(parser multiparser.Parser, vaultConfigFile string, configurations chan<- *configFile, sleepTime time.Duration) {
 	// This handler will sleep for a exponential backoff amount of time and re-inject the failed configuration into the
 	// configurations channel to be re-applied to vault
-	// Eventually consistent model - all recovarable errors (5xx and configs that depend on other configs) will be eventually fixed
-	// non recovarable errors will be retried and keep failing every MAX BACKOFF seconds, increasing the error counters ont he vault-configurator pod.
+	// Eventually consistent model - all recoverable errors (5xx and configs that depend on other configs) will be eventually fixed
+	// non recoverable errors will be retried and keep failing every MAX BACKOFF seconds, increasing the error counters ont he vault-configurator pod.
 	logrus.Infof("Failed applying configuration file: %s , sleeping for %s before trying again", vaultConfigFile, sleepTime)
 	time.Sleep(sleepTime)
 	configurations <- parseConfiguration(parser, vaultConfigFile)

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -49,7 +49,7 @@ var unsealCmd = &cobra.Command{
 	Use:   "unseal",
 	Short: "Unseals Vault with with unseal keys stored in one of the supported Cloud Provider options.",
 	Long: `It will continuously attempt to unseal the target Vault instance, by retrieving unseal keys
-from one of the followings:
+from one of the following:
 - Google Cloud KMS keyring (backed by GCS)
 - AWS KMS keyring (backed by S3)
 - Azure Key Vault

--- a/internal/configuration/template.go
+++ b/internal/configuration/template.go
@@ -41,15 +41,15 @@ import (
 )
 
 const (
-	// DefaultLeftDelimiter is the default left-hand delimeter that will be used for the templates
+	// DefaultLeftDelimiter is the default left-hand delimiter that will be used for the templates
 	DefaultLeftDelimiter = "${"
-	// DefaultRightDelimiter is the default right-hand delimeter that will be used for the templates
+	// DefaultRightDelimiter is the default right-hand delimiter that will be used for the templates
 	DefaultRightDelimiter = "}"
 )
 
 const templateName = "config"
 
-// Templater is used to hold the delimeters used to configure the template engine
+// Templater is used to hold the delimiters used to configure the template engine
 type Templater struct {
 	leftDelimiter  string
 	rightDelimiter string

--- a/internal/vault/audits.go
+++ b/internal/vault/audits.go
@@ -103,7 +103,7 @@ func (v *vault) removeUnmanagedAudits(unmanagedAudits map[string]bool) error {
 	}
 
 	for auditPath := range unmanagedAudits {
-		logrus.Infof("removing unmanged audit device %s", auditPath)
+		logrus.Infof("removing unmanaged audit device %s", auditPath)
 		err := v.cl.Sys().DisableAudit(auditPath)
 		if err != nil {
 			return errors.Wrapf(err, "error disabling %s audit in vault", auditPath)

--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -52,7 +52,7 @@ func initAuthConfig(auths []auth) []auth {
 
 		// Convert `map[interface{}]interface{}` to `map[string]interface{}` before sending the config to Vault API.
 		// That's because the config data can have a sub dict (like `provider_config` in JWT/OIDC).
-		// Without this conversion, Vault API will retrun the following error:
+		// Without this conversion, Vault API will return the following error:
 		// `json: unsupported type: map[interface {}]interface {}`
 		for key, value := range auths[index].Config {
 			switch val := value.(type) {

--- a/internal/vault/identity_groups.go
+++ b/internal/vault/identity_groups.go
@@ -279,7 +279,7 @@ func (v *vault) addManagedGroupAliases(managedGroupAliases []groupAlias) error {
 }
 
 func (v *vault) getExistingGroupAliases() (map[string]string, error) {
-	existinGroupAliases := make(map[string]string)
+	existingGroupAliases := make(map[string]string)
 
 	existingGroupAliasesRaw, err := v.cl.Logical().ReadWithData(
 		"identity/group-alias/id", map[string][]string{"list": {"true"}})
@@ -295,10 +295,10 @@ func (v *vault) getExistingGroupAliases() (map[string]string, error) {
 	existingGroupAliasesData := cast.ToStringMap(existingGroupAliasesRaw.Data["key_info"])
 	for existingGroupAliasID, existingGroupAliasRaw := range existingGroupAliasesData {
 		existingGroupAlias := cast.ToStringMapString(existingGroupAliasRaw)
-		existinGroupAliases[existingGroupAlias["name"]] = existingGroupAliasID
+		existingGroupAliases[existingGroupAlias["name"]] = existingGroupAliasID
 	}
 
-	return existinGroupAliases, nil
+	return existingGroupAliases, nil
 }
 
 func getUnmanagedGroupAliases(existingGroupAliases map[string]string, managedGroupAliases []groupAlias) map[string]string {

--- a/internal/vault/plugins.go
+++ b/internal/vault/plugins.go
@@ -70,7 +70,7 @@ func (v *vault) getExistingPlugins() (map[string]map[string]bool, error) {
 			if !builtinPlugins[existingPluginType.String()][existingPluginName] {
 				// Since the builtinPlugins map is non-exclusive, we still need to make sure that the existing plugin
 				// is not builtin plugin (for example, if Vault got some more builtin plugins).
-				// Hopfully that should be replaced when Vault exposes the builtin plugins only via the API.
+				// Hopefully that should be replaced when Vault exposes the builtin plugins only via the API.
 				input := api.GetPluginInput{
 					Name: existingPluginName,
 					Type: existingPluginType,

--- a/internal/vault/secrets_engines.go
+++ b/internal/vault/secrets_engines.go
@@ -32,9 +32,9 @@ func isOverwriteProhibitedError(err error) bool {
 	return strings.Contains(err.Error(), "delete them before reconfiguring")
 }
 
-// secretEnginesWihtoutNameConfig holds the secret engine types where
+// secretEnginesWithoutNameConfig holds the secret engine types where
 // the name shouldn't be part of the config path
-var secretEnginesWihtoutNameConfig = map[string]bool{
+var secretEnginesWithoutNameConfig = map[string]bool{
 	"ad":       true,
 	"alicloud": true,
 	"azure":    true,
@@ -162,7 +162,7 @@ func (v *vault) getUnmanagedSecretsEngines(managedSecretsEngines []secretEngine)
 
 func configNeedsNoName(secretEngineType string, configOption string) bool {
 	if configOption == "config" {
-		_, ok := secretEnginesWihtoutNameConfig[secretEngineType]
+		_, ok := secretEnginesWithoutNameConfig[secretEngineType]
 		return ok
 	}
 

--- a/pkg/kv/hsm/hsm.go
+++ b/pkg/kv/hsm/hsm.go
@@ -186,11 +186,11 @@ func New(config Config, storage kv.Service) (kv.Service, error) {
 	var encrypt cryptoFunc
 
 	if info.ManufacturerID == "OpenSC Project" {
-		log.Info("this HSM doesn't support on-device encryption, extracting public key and doing encrytion on the computer")
+		log.Info("this HSM doesn't support on-device encryption, extracting public key and doing encryption on the computer")
 
 		publicKeyValue, err := p11.Object(publicKey).Value()
 		if err != nil {
-			return nil, errors.WrapIf(err, "can't get puclic key value")
+			return nil, errors.WrapIf(err, "can't get public key value")
 		}
 
 		publicKey, err := x509.ParsePKCS1PublicKey(publicKeyValue)

--- a/pkg/kv/k8s/k8s.go
+++ b/pkg/kv/k8s/k8s.go
@@ -69,7 +69,7 @@ func New(namespace, secret string, labels map[string]string) (kv.Service, error)
 		ownerReference = &metav1.OwnerReference{}
 		err := json.Unmarshal([]byte(ownerReferenceJSON), ownerReference)
 		if err != nil {
-			return nil, errors.Wrap(err, "error unmarhsaling OwnerReference")
+			return nil, errors.Wrap(err, "error unmarshaling OwnerReference")
 		}
 	}
 

--- a/scripts/configure-sshd.sh
+++ b/scripts/configure-sshd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script configures your sshd daemon with the SSH certificats from Vault.
+# This script configures your sshd daemon with the SSH certificates from Vault.
 # It assumes that it is running in automation on a VM with Vault AppRole, thus needs:
 #  - VAULT_ROLE_ID: the AppRole's RoleID
 #  - VAULT_SECRET_ID: the AppRole's SecretID


### PR DESCRIPTION
## Overview

This PR corrects spelling mistakes in the error message, info logs, unexported variable names, cmd description, and comments.

## Notes for reviewer

Is it safe to change the error message? Because it can break functions that depend on this specific error message.