### PR TITLE
Replace deprecated io/ioutil with io and os

### DIFF
--- a/cmd/template/main.go
+++ b/cmd/template/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -67,7 +66,7 @@ func main() {
 			log.Fatalf("error executing template: %s", err.Error())
 		}
 
-		err = ioutil.WriteFile(filename, buffer.Bytes(), 0600)
+		err = os.WriteFile(filename, buffer.Bytes(), 0600)
 		if err != nil {
 			log.Fatalf("error writing template file: %s", err.Error())
 		}
@@ -81,7 +80,7 @@ func main() {
 			source := templateArray[0]
 			destination := templateArray[1]
 
-			templateText, err := ioutil.ReadFile(source)
+			templateText, err := os.ReadFile(source)
 			if err != nil {
 				log.Fatalf("error reading template file: %s", err.Error())
 			}
@@ -91,7 +90,7 @@ func main() {
 				log.Fatalf("error executing template: %s", err.Error())
 			}
 
-			err = ioutil.WriteFile(destination, templatedText.Bytes(), 0600)
+			err = os.WriteFile(destination, templatedText.Bytes(), 0600)
 			if err != nil {
 				log.Fatalf("error writing template file %q: %s", destination, err.Error())
 			}

--- a/internal/configuration/template.go
+++ b/internal/configuration/template.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -190,7 +189,7 @@ func gcpKmsDecrypt(encodedString string, projectID string, location string, keyR
 }
 
 func fileContent(path string) (string, error) {
-	r, err := ioutil.ReadFile(path)
+	r, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -16,7 +16,6 @@ package vault
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -208,11 +207,11 @@ func (v *vault) addAdditionalAuthConfig(authMethod auth) error {
 }
 
 func (v *vault) kubernetesAuthConfigDefault() (map[string]interface{}, error) {
-	kubernetesCACert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	kubernetesCACert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to read ca.crt")
 	}
-	tokenReviewerJWT, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	tokenReviewerJWT, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to read serviceaccount token")
 	}

--- a/pkg/kv/alibabaoss/oss.go
+++ b/pkg/kv/alibabaoss/oss.go
@@ -17,7 +17,7 @@ package alibabaoss
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"emperror.dev/errors"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
@@ -74,7 +74,7 @@ func (o *ossStorage) Get(key string) ([]byte, error) {
 		return nil, errors.Wrapf(err, "error getting object for key '%s'", objectKey)
 	}
 
-	b, err := ioutil.ReadAll(body)
+	b, err := io.ReadAll(body)
 	defer body.Close()
 
 	if err != nil {

--- a/pkg/kv/dev/dev.go
+++ b/pkg/kv/dev/dev.go
@@ -15,7 +15,6 @@
 package dev
 
 import (
-	"io/ioutil"
 	"os"
 
 	"emperror.dev/errors"
@@ -32,7 +31,7 @@ func New() (service kv.Service, err error) {
 	rootToken := []byte(os.Getenv("VAULT_TOKEN"))
 
 	if len(rootToken) == 0 {
-		rootToken, err = ioutil.ReadFile(os.Getenv("HOME") + "/.vault-token")
+		rootToken, err = os.ReadFile(os.Getenv("HOME") + "/.vault-token")
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating dev client")
 		}

--- a/pkg/kv/file/file.go
+++ b/pkg/kv/file/file.go
@@ -15,7 +15,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -36,11 +35,11 @@ func New(path string) (service kv.Service, err error) {
 }
 
 func (f *file) Set(key string, val []byte) error {
-	return ioutil.WriteFile(path.Join(f.path, key), val, 0600)
+	return os.WriteFile(path.Join(f.path, key), val, 0600)
 }
 
 func (f *file) Get(key string) ([]byte, error) {
-	val, err := ioutil.ReadFile(path.Join(f.path, key))
+	val, err := os.ReadFile(path.Join(f.path, key))
 	if os.IsNotExist(err) {
 		return nil, kv.NewNotFoundError("key '%s' is not present in file", key)
 	}

--- a/pkg/kv/gcs/gcs.go
+++ b/pkg/kv/gcs/gcs.go
@@ -17,7 +17,7 @@ package gcs
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"cloud.google.com/go/storage"
 	"emperror.dev/errors"
@@ -69,7 +69,7 @@ func (g *gcsStorage) Get(key string) ([]byte, error) {
 
 	defer r.Close()
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading object with key '%s'", n)
 	}

--- a/pkg/kv/s3/s3.go
+++ b/pkg/kv/s3/s3.go
@@ -17,7 +17,7 @@ package s3
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
@@ -101,7 +101,7 @@ func (s3 *s3Storage) Get(key string) ([]byte, error) {
 		return nil, errors.Wrapf(err, "error getting object for key '%s'", n)
 	}
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	defer r.Body.Close()
 
 	if err != nil {


### PR DESCRIPTION
## Overview

This PR replaces the deprecated in Go 1.17 package [io/ioutil](https://pkg.go.dev/io/ioutil) with `io` and `os` packages. 

## Notes for reviewer

The changes are not user-facing and are safe to merge.
