### PR TITLE
chore: fix buildtag

### DIFF
--- a/pkg/kv/hsm/hsm_test.go
+++ b/pkg/kv/hsm/hsm_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build integration
+//go:build integration
 
 package hsm
 


### PR DESCRIPTION
## Overview

This PR fixes the build tag in one test file via running `go fix ./...`.

## Notes for reviewers

`// +build` has been obsolete since Go 1.18. It was replaced by `//go:build`. See [the SO answer](https://stackoverflow.com/questions/10646531/golang-conditional-compilation/67937234#67937234) for details.