### PR TITLE
fix: dupword lint; mark few linters as deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,9 @@ linters:
     - varcheck
     - structcheck
     - deadcode
+    - golint
+    - scopelint
+    - nosnakecase
 
     # TODO: fixme
     - paralleltest
@@ -42,21 +45,16 @@ linters:
     - gochecknoinits
     - goconst
     - gocognit
-    - golint
-    - scopelint
     - gocritic
     - stylecheck
     - gocyclo
     - testpackage
     - varnamelen
     - ireturn
-    - nosnakecase
     - exhaustruct
     - nonamedreturns
     - nilnil
-    - contextcheck
     - maintidx
-    - dupword
     - gosec
     - gomoddirectives
     - gci

--- a/cmd/bank-vaults/common.go
+++ b/cmd/bank-vaults/common.go
@@ -256,7 +256,7 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 			k8sSecretLabels,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "error creating K8S Secret with with kv store")
+			return nil, errors.Wrap(err, "error creating K8S Secret with kv store")
 		}
 
 		config := hsm.Config{

--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -116,7 +116,7 @@ const (
 	cfgOnce         = "once"
 )
 
-// We need to pre-create a value and bind the the flag to this until
+// We need to pre-create a value and bind the flag to this until
 // https://github.com/spf13/viper/issues/608 gets fixed.
 var (
 	k8sSecretLabels         map[string]string

--- a/cmd/bank-vaults/unseal.go
+++ b/cmd/bank-vaults/unseal.go
@@ -47,7 +47,7 @@ type unsealCfg struct {
 
 var unsealCmd = &cobra.Command{
 	Use:   "unseal",
-	Short: "Unseals Vault with with unseal keys stored in one of the supported Cloud Provider options.",
+	Short: "Unseals Vault with unseal keys stored in one of the supported Cloud Provider options.",
 	Long: `It will continuously attempt to unseal the target Vault instance, by retrieving unseal keys
 from one of the following:
 - Google Cloud KMS keyring (backed by GCS)

--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -303,7 +303,7 @@ func (v *vault) configureJwtRoles(path string, roles []interface{}) error {
 		if err != nil {
 			return errors.Wrap(err, "error converting roles for jwt")
 		}
-		// role can have have a bound_claims or claim_mappings child dict. But it will cause:
+		// role can have a bound_claims or claim_mappings child dict. But it will cause:
 		// `json: unsupported type: map[interface {}]interface {}`
 		// So check and replace by `map[string]interface{}` before using it.
 		if val, ok := role["bound_claims"]; ok {


### PR DESCRIPTION
## Overview

This PR modifies `golangci-lint` config:

- enables and fixes `dupword` lint issues;
- enables `exhaustruct`, `contextcheck` linters;
- moves `golint, scopelint, nosnakecase` under the deprecated comment. 

