### PR TITLE
fix: Issue #1823 - moving vault keys from kube secret to aws s3

### DIFF
--- a/pkg/kv/awskms/awskms.go
+++ b/pkg/kv/awskms/awskms.go
@@ -15,6 +15,8 @@
 package awskms
 
 import (
+        "encoding/base64"
+
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -71,7 +73,7 @@ func (a *awsKMS) decrypt(cipherText []byte) ([]byte, error) {
 		return nil, errors.WrapIf(err, "failed to decrypt with KMS client")
 	}
 
-	return out.Plaintext, nil
+	return base64.StdEncoding.DecodeString(string(out.Plaintext))
 }
 
 func (a *awsKMS) Get(key string) ([]byte, error) {

--- a/pkg/kv/awskms/awskms.go
+++ b/pkg/kv/awskms/awskms.go
@@ -15,7 +15,7 @@
 package awskms
 
 import (
-        "encoding/base64"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,7 +73,9 @@ func (a *awsKMS) decrypt(cipherText []byte) ([]byte, error) {
 		return nil, errors.WrapIf(err, "failed to decrypt with KMS client")
 	}
 
-	return base64.StdEncoding.DecodeString(string(out.Plaintext))
+	trimKey := strings.TrimSpace(string(out.Plaintext))
+
+	return []byte(trimKey), nil
 }
 
 func (a *awsKMS) Get(key string) ([]byte, error) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview
Regarding issue #1823.  When migrating keys from kubernetes secret to s3 bucket, the migrate script https://bank-vaults.dev/docs/unseal-keys/#aws-1 results in a key with a newline at end.  When retrieved from the s3 bucket and passed to vault, vault rejects the key.  
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #1823 
added strings.TrimSpace(string(out.Plaintext)) to remove trailing newline.
Tested by deploying to private ecr, editing pod vault-configurer and updating with private ecr image.  Configurer was able to config audit device.  Edited each of the vault-X pods with private ecr image.  Vault pods were able to connect to vault and unseal.
## Notes for reviewer
I am not sure if this could be fixed in the script.  TrimSpace will not hurt existing installations as the the key value will not be changed.
<!-- Anything the reviewer should know? -->
