### PR TITLE
feat: Allow to set transit cache-config

### DIFF
--- a/internal/vault/secrets_engines.go
+++ b/internal/vault/secrets_engines.go
@@ -170,6 +170,10 @@ func configNeedsNoName(secretEngineType string, configOption string) bool {
 		return true
 	}
 
+	if secretEngineType == "transit" && configOption == "cache-config" {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This MR fixes #2462 to set the cache-config of the secrets engine

## Notes for reviewer

<!-- Anything the reviewer should know? -->
