### PR TITLE
fix: Use correct unseal key name in cofigurer

### DIFF
--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -468,6 +468,11 @@ func (v *vault) Configure(config map[string]interface{}) error {
 
 		slog.Debug("initiating generate-root token process...")
 
+		// Cancel any inflight root token generation that is a remnant from a previous attempt
+		err := v.cl.Sys().GenerateRootCancel()
+		if err != nil {
+			return errors.Wrapf(err, "unable to cancel generate root token process")
+		}
 		response, err := v.cl.Sys().GenerateRootInit("", "")
 		if err != nil {
 			return errors.Wrapf(err, "unable to initiate generate-root token process")

--- a/pkg/kv/awskms/awskms.go
+++ b/pkg/kv/awskms/awskms.go
@@ -65,6 +65,7 @@ func New(store kv.Service, region string, kmsID string, encryptionContext map[st
 
 func (a *awsKMS) decrypt(cipherText []byte) ([]byte, error) {
 	out, err := a.kmsService.Decrypt(&kms.DecryptInput{
+		KeyId:             aws.String(a.kmsID),
 		CiphertextBlob:    cipherText,
 		EncryptionContext: a.encryptionContext,
 		GrantTokens:       []*string{},


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview
This PR fixes a bug in the configurer in cases where a recovery type unseal is used.
The configurer first checks what key type to use before getting it from the key store.
I've also added a fix for canceling any inflight root token generations that are remnants from previous attempts.
Another fix I added was the missing KMS key ID from the decrypt function.
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

<!-- Anything the reviewer should know? -->
