### PR TITLE
chore: bump goreleaser

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -210,7 +210,7 @@ jobs:
         with:
           cond: ${{ inputs.release }}
           if_true: goreleaser release
-          if_false: goreleaser release --skip-publish --snapshot
+          if_false: goreleaser release --skip=publish --snapshot
 
       - name: Build
         run: nix develop --impure .#ci -c ${{ steps.build-command.outputs.value }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    ldflags: "-s -w -X main.version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}"
+    ldflags: "-s -w -X main.Version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}"
     main: ./cmd/template
     goos:
       - linux
@@ -26,7 +26,7 @@ builds:
       - arm64
     hooks:
       post:
-        - xgo -targets {{ .Os }}/{{ .Arch }} -dest build/dist -ldflags '-s -w -X main.version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}' -pkg cmd/bank-vaults .
+        - xgo -targets {{ .Os }}/{{ .Arch }} -dest build/dist -ldflags '-s -w -X main.Version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}' -pkg cmd/bank-vaults .
         - sudo bash -c "mkdir -p build/dist/bank-vaults_{{ .Os }}_{{ .Arch }}; mv build/dist/github.com/bank-vaults/bank-vaults-{{ .Os }}-{{ .Arch }} build/dist/bank-vaults_{{ .Os }}_{{ .Arch }}/bank-vaults"
 
 archives:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,18 +1,23 @@
-dist: build/dist
-
 # Requirements:
 # - Docker
 # - go install github.com/crazy-max/xgo@latest
+version: 2
+
+project_name: bank-vaults
+
+dist: build/dist
+
+before:
+  hooks:
+    - go mod tidy
+# Building of Bank-Vaults is a bit hacky since the pkcs11 package can't be built with simple Go Crosscompiling
+# so we need to use xgo, but that is not directly supported in GoReleaser, so we do the actual compilation with
+# xgo in post hooks for all targets.
 builds:
-  # Building of Bank-Vaults is a bit hacky since the pkcs11 package can't be built with simple Go Crosscompiling
-  # so we need to use xgo, but that is not directly supported in GoReleaser, so we do the actual compilation with
-  # xgo in post hooks for all targets.
-  - main: ./cmd/template
-    env:
+  - env:
       - CGO_ENABLED=0
-    flags:
-      - -trimpath
     ldflags: "-s -w -X main.version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}"
+    main: ./cmd/template
     goos:
       - linux
       - darwin
@@ -25,16 +30,21 @@ builds:
         - sudo bash -c "mkdir -p build/dist/bank-vaults_{{ .Os }}_{{ .Arch }}; mv build/dist/github.com/bank-vaults/bank-vaults-{{ .Os }}-{{ .Arch }} build/dist/bank-vaults_{{ .Os }}_{{ .Arch }}/bank-vaults"
 
 archives:
-  - name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        format: zip
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 checksum:
   name_template: "bank-vaults_checksums.txt"
 
 changelog:
-  skip: false
+  disable: true
 
 release:
   prerelease: auto

--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var c = viper.New()
+var Version = "v1.31.1"
 
 const (
 	cfgSecretShares    = "secret-shares"
@@ -124,6 +124,8 @@ const (
 	cfgUnsealPeriod = "unseal-period"
 	cfgOnce         = "once"
 )
+
+var c = viper.New()
 
 var rootCmd = &cobra.Command{
 	Use:   "bank-vaults",

--- a/cmd/template/main.go
+++ b/cmd/template/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/bank-vaults/internal/configuration"
 )
 
+var Version = "v1.31.1"
+
 type arrayFlags []string
 
 func (i *arrayFlags) String() string {

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1716847473,
-        "narHash": "sha256-Sn3PpgNAmV9pLr8pefvVAiHzBebq23nFf5QeHqMfVGk=",
+        "lastModified": 1719228706,
+        "narHash": "sha256-9C9H8lguX/Bay1VzkuontOG7v0vLJVhEhtH6yRwi5fk=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "60ed3dba92ed027bb886611b53cf9b9d1e7f149e",
+        "rev": "9dd2ea01c1ff9709826c098b589bb779ce85ab28",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1715865404,
-        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -286,14 +286,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1714640452,
-        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "nixpkgs-regression": {
@@ -362,11 +362,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1716715802,
-        "narHash": "sha256-usk0vE7VlxPX8jOavrtpOqphdfqEQpf9lgedlY/r66c=",
+        "lastModified": 1719223410,
+        "narHash": "sha256-jtIo8xR0Zp4SalIwmD+OdCwHF4l7OU6PD63UUK4ckt4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2dd4e18cc1c7314e24154331bae07df76eb582f",
+        "rev": "efb39c6052f3ce51587cf19733f5f4e5d515aa13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Overview

- This PR bumps Goreleaser to 2.0.0

