### PR TITLE
chore(build): check calling repository before cosign signing

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -121,7 +121,7 @@ jobs:
           # push: ${{ inputs.publish }}
 
       - name: Sign image with GitHub OIDC Token
-        if: inputs.publish
+        if: ${{ inputs.publish && github.repository_owner == 'bank-vaults' }} # Check if the workflow is called by the same GitHub organization
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Overview

This PR adds a check into the artifact signing step of the build process, so the workflow will only sign the artifact (using cosign) when it's called by the repositories within the same GitHub organization.

This fix is to prevent other arbitrary repositories from using the certificate identity `https://github.com/bank-vaults/bank-vaults/.github/workflows/artifacts.yaml@refs/heads/main` to sign their artifacts

## Notes for reviewer

The cosign feature was originally added by this PR: https://github.com/bank-vaults/bank-vaults/pull/2756
