### PR TITLE
fix: don't set static token_reviewer_jwt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,13 +10,11 @@ require (
 	github.com/aws/aws-sdk-go v1.54.18
 	github.com/bank-vaults/internal v0.3.1
 	github.com/bank-vaults/vault-sdk v0.9.4
-	github.com/cristalhq/jwt/v3 v3.1.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/hcl v1.0.1-vault-5
 	github.com/hashicorp/vault/api v1.14.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/json-iterator/go v1.1.12
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/prometheus/client_golang v1.19.1
@@ -32,6 +30,8 @@ require (
 	k8s.io/client-go v0.30.2
 	sigs.k8s.io/controller-runtime v0.18.4
 )
+
+require github.com/json-iterator/go v1.1.12 // indirect
 
 require (
 	cloud.google.com/go v0.115.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cristalhq/jwt/v3 v3.1.0 h1:iLeL9VzB0SCtjCy9Kg53rMwTcrNm+GHyVcz2eUujz6s=
-github.com/cristalhq/jwt/v3 v3.1.0/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
## Overview

Vault supports reading its own /var/run/secrets/kubernetes.io/serviceaccount/token and since version 1.9.0 it can handle short lived tokens. The removed code prevented that handling to occur.

Looking at the compatibility matrix for vault operator I'd say loosing functionality for vault pre 1.9.0 should be fine:

https://github.com/bank-vaults/vault-operator/blob/main/VERSIONS.md

More details on how vault is handling Kubernetes tokens: https://developer.hashicorp.com/vault/docs/auth/kubernetes#kubernetes-1-21

Fixes #1603

