### PR TITLE
feat: switch from xgo to gorelaser-cross

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -209,8 +209,8 @@ jobs:
         id: build-command
         with:
           cond: ${{ inputs.release }}
-          if_true: goreleaser release
-          if_false: goreleaser release --skip=publish --snapshot
+          if_true: make release
+          if_false: make binary-snapshot
 
       - name: Build
         run: nix develop --impure .#ci -c ${{ steps.build-command.outputs.value }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,6 @@ builds:
       - PKG_CONFIG_PATH=/sysroot/macos/amd64/usr/local/lib/pkgconfig
       - CC=o64-clang
       - CXX=o64-clang++
-    flags:
-      - -mod=readonly
     ldflags:
       - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
 
@@ -40,8 +38,6 @@ builds:
       - PKG_CONFIG_PATH=/sysroot/macos/arm64/usr/local/lib/pkgconfig
       - CC=oa64-clang
       - CXX=oa64-clang++
-    flags:
-      - -mod=readonly
     ldflags:
       - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
 
@@ -56,8 +52,6 @@ builds:
       - CGO_ENABLED=1
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
-    flags:
-      - -mod=readonly
     ldflags:
       - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
 
@@ -72,8 +66,6 @@ builds:
       - CGO_ENABLED=1
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-    flags:
-      - -mod=readonly
     ldflags:
       - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,3 @@
-# Requirements:
-# - Docker
-# - go install github.com/crazy-max/xgo@latest
 version: 2
 
 project_name: bank-vaults
@@ -10,38 +7,90 @@ dist: build/dist
 before:
   hooks:
     - go mod tidy
-# Building of Bank-Vaults is a bit hacky since the pkcs11 package can't be built with simple Go Crosscompiling
-# so we need to use xgo, but that is not directly supported in GoReleaser, so we do the actual compilation with
-# xgo in post hooks for all targets.
+
 builds:
-  - env:
-      - CGO_ENABLED=0
-    ldflags: "-s -w -X main.Version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}"
+  - id: darwin-amd64
     main: ./cmd/template
+    binary: bank-vaults
     goos:
-      - linux
       - darwin
     goarch:
       - amd64
+    env:
+      - CGO_ENABLED=1
+      - PKG_CONFIG_SYSROOT_DIR=/sysroot/macos/amd64
+      - PKG_CONFIG_PATH=/sysroot/macos/amd64/usr/local/lib/pkgconfig
+      - CC=o64-clang
+      - CXX=o64-clang++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
+
+  - id: darwin-arm64
+    main: ./cmd/template
+    binary: bank-vaults
+    goos:
+      - darwin
+    goarch:
       - arm64
-    hooks:
-      post:
-        - xgo -targets {{ .Os }}/{{ .Arch }} -dest build/dist -ldflags '-s -w -X main.Version={{ .Version }} -X main.commitHash={{ .ShortCommit }} -X main.buildDate={{ .Date }}' -pkg cmd/bank-vaults .
-        - sudo bash -c "mkdir -p build/dist/bank-vaults_{{ .Os }}_{{ .Arch }}; mv build/dist/github.com/bank-vaults/bank-vaults-{{ .Os }}-{{ .Arch }} build/dist/bank-vaults_{{ .Os }}_{{ .Arch }}/bank-vaults"
+    env:
+      - CGO_ENABLED=1
+      - PKG_CONFIG_SYSROOT_DIR=/sysroot/macos/arm64
+      - PKG_CONFIG_PATH=/sysroot/macos/arm64/usr/local/lib/pkgconfig
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
+
+  - id: linux-amd64
+    main: ./cmd/template
+    binary: bank-vaults
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
+
+  - id: linux-arm64
+    main: ./cmd/template
+    binary: bank-vaults
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.Version={{.Version}} -X main.commitHash={{.ShortCommit}} -X main.buildDate={{.Date}}
 
 archives:
   - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName }}_{{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - README*
+      - LICENSE*
 
 checksum:
-  name_template: "bank-vaults_checksums.txt"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
 
 changelog:
   disable: true

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ container-image: ## Build container image
 binary-snapshot: ## Build binary snapshot
 	@docker run \
 		--rm \
-		-e CGO_ENABLED=1 \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
@@ -55,7 +54,6 @@ binary-snapshot: ## Build binary snapshot
 release: ## Release the project
 	@docker run \
 		--rm \
-		-e CGO_ENABLED=1 \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,6 @@
               gnumake
 
               golangci-lint
-              goreleaser
 
               yq-go
               jq
@@ -65,10 +64,9 @@
               versions.exec = ''
                 go version
                 golangci-lint version
-                echo controller-gen $(controller-gen --version)
                 kind version
                 kubectl version --client
-                echo kustomize $(kustomize version --short)
+                echo kustomize $(kustomize version)
                 echo helm $(helm version --short)
               '';
             };


### PR DESCRIPTION
## Overview
- Building of Bank-Vaults was a bit hacky since the pkcs11 package can't be built with simple Go Crosscompiling, so we used xgo, but that is not directly supported in GoReleaser, so we did the actual compilation with xgo in post hooks for all targets.
- This PR introduces [Goreleaser-cross](https://github.com/goreleaser/goreleaser-cross)

Fixes #2074

