### PR TITLE
feat: add support for AWS Identity Integration

### DIFF
--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -242,6 +242,16 @@ func (v *vault) configureAwsConfig(path string, config map[string]interface{}) e
 	return nil
 }
 
+func (v *vault) configureAwsIdentityIntegration(path string, config map[string]interface{}) error {
+	// https://developer.hashicorp.com/vault/api-docs/auth/aws#configure-identity-integration
+	_, err := v.writeWithWarningCheck(fmt.Sprintf("auth/%s/config/identity", path), config)
+	if err != nil {
+		return errors.Wrap(err, "error configuring aws identity integration into vault")
+	}
+
+	return nil
+}
+
 func (v *vault) configureUserpassUsers(path string, users interface{}) error {
 	usersAsserted, _ := users.([]interface{})
 	for _, userRaw := range usersAsserted {
@@ -414,6 +424,29 @@ func (v *vault) addManagedAuthMethods(managedAuths []auth) error {
 		err := v.addAdditionalAuthConfig(authMethod)
 		if err != nil {
 			return errors.Wrapf(err, "error while adding auth method config")
+		}
+
+		// This configuration only makes sense if authentication is done against AWS
+		// However, AWS authentication can be configured using an "aws" or "plugin" backend.
+		// Since it's not specific for only one backend type,
+		// this code lives in this function rather than in addAdditionalAuthConfig
+		if authMethod.Config != nil {
+			for configOption, configDataRaw := range authMethod.Config {
+				slog.Debug(fmt.Sprintf("Handling auth method config option: %s", configOption))
+				switch configOption {
+				case "aws-identity-integration":
+					configData, err := cast.ToStringMapE(configDataRaw)
+					if err != nil {
+						return errors.Wrap(err, "error converting configDataRaw for aws-identity-integration configuration")
+					}
+					err = v.configureAwsIdentityIntegration(authMethod.Path, configData)
+					if err != nil {
+						return errors.Wrap(err, "error configuring plugin identity integration")
+					}
+				default:
+					return errors.Wrap(err, "Unmanaged configuration option")
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This PR adds support for AWS Identity Integration: https://developer.hashicorp.com/vault/api-docs/auth/aws#configure-identity-integration.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)
https://github.com/bank-vaults/bank-vaults/issues/2621

## Pre-existing behaviour
### Configuration file before the change
```
auth:
- path: aws-iam
  type: aws
  roles:
    - name: test
      bound_iam_instance_profile_arn:
        - <your instance profile>
      policies:
        - <your policy>
      ttl: 12h
      inferred_entity_type: ec2_instance
      inferred_aws_region: <your aws region>
      auth_type: iam
      token_type: service
```

### Output
```
$ vault read /auth/aws-iam/config/identity
Key             Value
---             -----
...
iam_metadata    [account_id auth_type]
```
The IAM metadata value is [account_id auth_type] by default.

## Tests of the new behaviour
### Configuration file 
```
auth:
- path: aws-iam
  type: aws
  config:
    aws-identity-integration:
      iam_metadata: canonical_arn
  roles:
<unchanged>
```

### Output
```
$ vault read /auth/aws-iam/config/identity
Key             Value
---             -----
...
iam_metadata    [canonical_arn]
```

The IAM metadata value is correctly updated to the value passed in input.