### PR TITLE
feat: Vault plugins can be used for authentication

### DIFF
--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -98,6 +98,12 @@ func (v *vault) addAdditionalAuthConfig(authMethod auth) error {
 			return errors.Wrap(err, "error configuring github mappings for vault")
 		}
 
+	case "plugin":
+		err := v.configureGenericAuthRoles(authMethod.Type, authMethod.Path, "role", authMethod.Roles)
+		if err != nil {
+			return errors.Wrap(err, "error configuring plugin auth roles for vault")
+		}
+
 	case "aws":
 		err := v.configureAwsConfig(authMethod.Path, authMethod.Config)
 		if err != nil {

--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -568,16 +568,16 @@ func (v *vault) Configure(config map[string]interface{}) error {
 		return errors.Wrap(err, "error configuring audit devices for vault")
 	}
 
+	if err = v.configurePlugins(); err != nil {
+		return errors.Wrap(err, "error configuring plugins for vault")
+	}
+
 	if err = v.configureAuthMethods(); err != nil {
 		return errors.Wrap(err, "error configuring auth methods for vault")
 	}
 
 	if err = v.configureIdentityGroups(); err != nil {
 		return errors.Wrap(err, "error writing groups configurations for vault")
-	}
-
-	if err = v.configurePlugins(); err != nil {
-		return errors.Wrap(err, "error configuring plugins for vault")
 	}
 
 	if err = v.configurePolicies(); err != nil {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

To be able to use a plugin as authentication backend, plugins need to be loaded before authentication configuration happens. Once loaded, the plugin can now be used as authentication method.

It would be used with a config file like the following:
```
auth:
- path: aws-iam
  type: plugin
  options:
    plugin_name: my-vault-plugin-auth-aws
  roles:
    - name: 'myRoleName'
      bound_iam_instance_profile_arn:
        - 'myInstanceProfile'
      ttl: 12h
      inferred_entity_type: ec2_instance
      inferred_aws_region: us-east-1
      auth_type: iam
      token_type: service
plugins:
- plugin_name: vault-plugin-auth-aws
  command: vault-plugin-auth-aws
  sha256: <sha256hash>
  type: auth
```


<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)
https://github.com/bank-vaults/bank-vaults/issues/3091

## Notes for reviewer

<!-- Anything the reviewer should know? -->
