### PR TITLE
fix: only first auth mount with authMethod.Config would be configured

### DIFF
--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -450,7 +450,7 @@ func (v *vault) addManagedAuthMethods(managedAuths []auth) error {
 						return errors.Wrap(err, "error configuring plugin identity integration")
 					}
 				default:
-					return errors.Wrap(err, "Unmanaged configuration option")
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
## Overview
Fixes an issue where if authMethod.Config is present only the first auth mount is configured even if multiple are included in the config file.

This is because the additional configuration code added in https://github.com/bank-vaults/bank-vaults/pull/3089 to support the `aws-identity-integration` option returns an error for all other `configOptions` rather than continuing to loop over each subsequent option. The result is that `addManagedAuthMethods` returns immediately after configuring the first auth mount, skipping any additional auth mounts.

This issue was silently occurring because `errors.Wrap` returns nil if err = nil so when this default case was being hit it was returning from `addManagedAuthMethods` early with a nil err.

Fixes https://github.com/bank-vaults/bank-vaults/issues/3227

# Verification
Verified manually by applying a config file with multiple auth mounts locally.
