### PR TITLE
fix: keys may not exist yet

### DIFF
--- a/internal/vault/operator_client.go
+++ b/internal/vault/operator_client.go
@@ -392,6 +392,10 @@ func (v *vault) RaftInitialized() (bool, error) {
 		for i := 0; i < v.config.SecretShares; i++ {
 			unsealKey, err := v.keyStore.Get(keyUnsealForID(i))
 			if err != nil {
+				// It's ok if there are no keys  
+				if isNotFoundError(err) {
+					return false, nil
+				}
 				return false, errors.Wrapf(err, "unable to get key '%s'", keyUnsealForID(i))
 			}
 			if len(unsealKey) == 0 {


### PR DESCRIPTION

## Overview

Fixes #(issue)

We should not throw error when unseal keys are not found or else first pod can't initialize the Vault Cluster
I've introduced this error in PR #3310. Related to issue #3309 




## Notes for reviewer

<!-- Anything the reviewer should know? -->
