### PR TITLE
Fix config handling appending instead of replacing across auth backends

### DIFF
--- a/e2e/validate-config-crud/vault-config.yaml
+++ b/e2e/validate-config-crud/vault-config.yaml
@@ -33,6 +33,26 @@ auth:
     type: userpass
   # The "path" would be defaulted to "type".
   - type: userpass
+  # Test auth methods with roles for retry state pollution bug
+  # Using approle which requires no external connectivity
+  - type: approle
+    path: approle1
+    roles:
+      - name: approle-role-1
+        token_policies:
+          - policy_foo
+        token_ttl: 1h
+        token_max_ttl: 4h
+        bind_secret_id: true
+  - type: approle
+    path: approle2
+    roles:
+      - name: approle-role-2
+        token_policies:
+          - policy_bar
+        token_ttl: 2h
+        token_max_ttl: 8h
+        bind_secret_id: true
 
 groups:
   - name: group_foo


### PR DESCRIPTION
# Bank-Vaults Configuration Retry State Pollution Bug

## Summary

The vault-configurer accumulates corrupted state across failed retry attempts due to mapstructure's append behavior combined with premature state updates. This causes roles from one auth method to appear in another auth method after configuration failures and retries.

## Observed Behavior

- Vault configuration fails with error: `"bound_service_account_names" can not be empty` for role `some-aws-role` in kubernetes auth method `some-k8s-backend`
- Role `some-aws-role` is an **AWS auth role**, not a kubernetes auth role
- The role only exists in the `aws` auth method in the actual configuration YAML
- Restarting the vault-configurer pod fixes the issue immediately
- Bug likely occurs when adding new auth backends after configurator has experienced failures

## Root Cause

### Location
`/internal/vault/operator_client.go`, function `Configure()`, lines 564-598

### The Fatal Flow

**First Configuration Attempt (fails):**
1. `Configure()` called with config map
2. Line 566: Deep copy `v.externalConfig` → `loadedConfig` via mapstructure
3. Line 582: Decode (merge) input `config` into `loadedConfig`
4. **Line 587: `v.externalConfig = &loadedConfig`** ← **State updated BEFORE validation!**
5. Line 597: `configureAuthMethods()` begins processing
6. Processes first kubernetes auth method (succeeds)
7. Processes `some-k8s-backend` kubernetes auth
8. **FAILS** with validation error on malformed role data
9. Returns error, triggering retry via `handleConfigurationError()`

**Retry Attempt (corrupted state):**
1. `Configure()` called AGAIN (after backoff sleep)
2. Line 566: Copy `v.externalConfig` (which **already contains data from failed attempt**)
3. Line 582: Decode input config into `loadedConfig`
   - **mapstructure APPENDS to slices by default** (no `ZeroFields: true` set)
   - Auth slice now contains **merged/duplicated data** from previous + current attempt
   - Slice references may become shared or corrupted
4. Line 587: `v.externalConfig = &loadedConfig` (with corrupted merged data)
5. Line 597: `configureAuthMethods()` processes corrupted auth slice
6. Roles from one auth method leak into another due to accumulated state
