### PR TITLE
fix(dependabot): properly group weekly dependencies (#2700)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,11 +11,24 @@ updates:
       time: "16:00"
     open-pull-requests-limit: 10
     groups:
-      k8s:
+      k8s.io:
         patterns:
-          - "k8s.io/api"
-          - "k8s.io/apimachinery"
-          - "k8s.io/client-go"
+          - "k8s.io/*"
+      sigs.k8s.io:
+        patterns:
+          - "sigs.k8s.io/*"
+      github.com/aws/aws-sdk-go-v2:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+      cloud.google.com/go:
+        patterns:
+          - "cloud.google.com/go*"
+      github.com/Azure:
+        patterns:
+          - "github.com/Azure/*"
+      github.com/hashicorp:
+        patterns:
+          - "github.com/hashicorp/*"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -36,3 +49,7 @@ updates:
       day: "sunday"
       time: "16:00"
     open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Overview

This PR fixes the Dependabot configuration so it properly groups dependency updates instead of opening individual PRs daily. 

Previously, the `k8s` group was using explicit package names (`k8s.io/api`, `k8s.io/client-go`, etc.) instead of wildcards, and many heavily used dependency families (like AWS SDK, Google Cloud, Azure, HashiCorp) were completely missing from the grouping configuration. This caused Dependabot to fall back to its default behavior of opening individual PRs for each ungrouped dependency.

I've updated `.github/dependabot.yaml` to:
1. Use wildcard patterns for the `k8s.io` group (e.g., `k8s.io`).
2. Add missing groups for `sigs.k8s.io`, `github.com/aws/aws-sdk-go-v2`, `cloud.google.com/go`, `github.com/Azure`, and `github.com/hashicorp`.
3. Add a grouped `actions` wildcard pattern for the `github-actions` ecosystem.

The group naming and patterns now align with the organizational conventions used in other repositories like `secrets-webhook` and `vault-sdk`.

Fixes #2700

## Notes for reviewer

I intentionally left standalone packages (e.g., `spf13/cobra`, `stretchr/testify`) out of the grouping logic so we don't create an artificial "catch-all" group, mapping closely to how the rest of the Bank-Vaults org configures Dependabot.
