### PR TITLE
fix: filter aws-identity-integration key from client config

### DIFF
--- a/internal/vault/auth_methods.go
+++ b/internal/vault/auth_methods.go
@@ -17,6 +17,7 @@ package vault
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"strings"
 
@@ -245,9 +246,26 @@ func (v *vault) configureGithubMappings(path string, mappings map[string]interfa
 	return nil
 }
 
+// configKeyAwsIdentityIntegration is the config key for AWS identity
+const configKeyAwsIdentityIntegration = "aws-identity-integration"
+
+// filterAwsClientConfig returns a copy of config without keys that are
+// handled separately (e.g. aws-identity-integration)
+func filterAwsClientConfig(config map[string]interface{}) map[string]interface{} {
+	filtered := maps.Clone(config)
+	if filtered == nil {
+		filtered = map[string]interface{}{}
+	}
+	delete(filtered, configKeyAwsIdentityIntegration)
+	return filtered
+}
+
 func (v *vault) configureAwsConfig(path string, config map[string]interface{}) error {
 	// https://www.vaultproject.io/api/auth/aws/index.html
-	_, err := v.writeWithWarningCheck(fmt.Sprintf("auth/%s/config/client", path), config)
+	// Always write the filtered client config, even when it is empty, so the
+	// configurer can clear any previously-set auth/{path}/config/client values
+	// in Vault while still excluding keys handled by other endpoints.
+	_, err := v.writeWithWarningCheck(fmt.Sprintf("auth/%s/config/client", path), filterAwsClientConfig(config))
 	if err != nil {
 		return errors.Wrap(err, "error putting aws config into vault")
 	}
@@ -445,14 +463,14 @@ func (v *vault) addManagedAuthMethods(managedAuths []auth) error {
 			for configOption, configDataRaw := range authMethod.Config {
 				slog.Debug(fmt.Sprintf("Handling auth method config option: %s", configOption))
 				switch configOption {
-				case "aws-identity-integration":
+				case configKeyAwsIdentityIntegration:
 					configData, err := cast.ToStringMapE(configDataRaw)
 					if err != nil {
 						return errors.Wrap(err, "error converting configDataRaw for aws-identity-integration configuration")
 					}
 					err = v.configureAwsIdentityIntegration(authMethod.Path, configData)
 					if err != nil {
-						return errors.Wrap(err, "error configuring plugin identity integration")
+						return errors.Wrap(err, "error configuring aws identity integration")
 					}
 				default:
 					continue

--- a/internal/vault/auth_methods_test.go
+++ b/internal/vault/auth_methods_test.go
@@ -1,0 +1,169 @@
+// Copyright © 2026 Bank-Vaults Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitAuthConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []auth
+		expected []auth
+	}{
+		{
+			name: "sets path to type when path is empty",
+			input: []auth{
+				{Type: "aws", Path: ""},
+			},
+			expected: []auth{
+				{Type: "aws", Path: "aws"},
+			},
+		},
+		{
+			name: "preserves explicit path",
+			input: []auth{
+				{Type: "aws", Path: "custom-aws"},
+			},
+			expected: []auth{
+				{Type: "aws", Path: "custom-aws"},
+			},
+		},
+		{
+			name: "handles multiple auth methods",
+			input: []auth{
+				{Type: "kubernetes", Path: ""},
+				{Type: "aws", Path: "aws-prod"},
+				{Type: "github", Path: ""},
+			},
+			expected: []auth{
+				{Type: "kubernetes", Path: "kubernetes"},
+				{Type: "aws", Path: "aws-prod"},
+				{Type: "github", Path: "github"},
+			},
+		},
+		{
+			name:     "handles empty auth list",
+			input:    []auth{},
+			expected: []auth{},
+		},
+		{
+			name: "converts nested map types in config",
+			input: []auth{
+				{
+					Type: "jwt",
+					Path: "jwt",
+					Config: map[string]interface{}{
+						"oidc_discovery_url": "https://example.com",
+						"provider_config": map[interface{}]interface{}{
+							"provider": "azure",
+						},
+					},
+				},
+			},
+			expected: []auth{
+				{
+					Type: "jwt",
+					Path: "jwt",
+					Config: map[string]interface{}{
+						"oidc_discovery_url": "https://example.com",
+						"provider_config": map[string]interface{}{
+							"provider": "azure",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := initAuthConfig(tt.input)
+			require.Len(t, result, len(tt.expected))
+			for i := range result {
+				assert.Equal(t, tt.expected[i].Type, result[i].Type)
+				assert.Equal(t, tt.expected[i].Path, result[i].Path)
+				assert.Equal(t, tt.expected[i].Config, result[i].Config)
+			}
+		})
+	}
+}
+
+func TestFilterAwsClientConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        map[string]interface{}
+		expectedKeys []string
+		excludedKeys []string
+	}{
+		{
+			name: "filters out aws-identity-integration",
+			input: map[string]interface{}{
+				"access_key": "test-access-key",
+				"secret_key": "test-secret-key",
+				"aws-identity-integration": map[string]interface{}{
+					"iam_alias": "role_id",
+				},
+			},
+			expectedKeys: []string{"access_key", "secret_key"},
+			excludedKeys: []string{"aws-identity-integration"},
+		},
+		{
+			name: "keeps all standard keys when no special keys present",
+			input: map[string]interface{}{
+				"access_key":   "test-access-key",
+				"secret_key":   "test-secret-key",
+				"sts_endpoint": "https://sts.example.com",
+				"iam_endpoint": "https://iam.example.com",
+			},
+			expectedKeys: []string{"access_key", "secret_key", "sts_endpoint", "iam_endpoint"},
+			excludedKeys: []string{},
+		},
+		{
+			name:         "handles empty config",
+			input:        map[string]interface{}{},
+			expectedKeys: []string{},
+			excludedKeys: []string{},
+		},
+		{
+			name:         "handles nil config",
+			input:        nil,
+			expectedKeys: nil,
+			excludedKeys: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterAwsClientConfig(tt.input)
+
+			if tt.input == nil {
+				assert.Equal(t, map[string]interface{}{}, result)
+				return
+			}
+			assert.NotNil(t, result)
+			for _, key := range tt.expectedKeys {
+				assert.Contains(t, result, key)
+			}
+			for _, key := range tt.excludedKeys {
+				assert.NotContains(t, result, key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

While investigating issue #3273, I found that the `aws-identity-integration` config key (added in #3089) was being forwarded to Vault's `auth/{path}/config/client` endpoint which doesn't expect that key. This could cause unexpected behavior when configuring AWS auth methods.

**Changes:**
- Extract `filterAwsClientConfig()` to strip out config keys that are handled separately in `addManagedAuthMethods` before sending them to the Vault API
- Ensure `configureAwsConfig` is called unconditionally to allow clearing previously-set client configurations when omitted
- Add unit tests for `initAuthConfig` and `filterAwsClientConfig`

Fixes #3273

## Notes for reviewer

The core regression fix (changing `default: return errors.Wrap(err, ...)` to `default: continue` in `addManagedAuthMethods`) was already merged in commit 0b835040. This PR adds robustness improvements on top of that specifically preventing the `aws-identity-integration` key from leaking to the wrong Vault endpoint and adding nil safety consistent with how other auth types handle it.

All existing tests continue to pass. New tests cover the filter logic and auth config initialization.
