### PR TITLE
feat: add key prefix support for Azure Key Vault backend

### DIFF
--- a/cmd/bank-vaults/common.go
+++ b/cmd/bank-vaults/common.go
@@ -185,7 +185,7 @@ func kvStoreForConfig(ctx context.Context, cfg *viper.Viper) (kv.Service, error)
 		return multi.New(services), nil
 
 	case cfgModeValueAzureKeyVault:
-		akv, err := azurekv.New(cfg.GetString(cfgAzureKeyVaultName))
+		akv, err := azurekv.New(cfg.GetString(cfgAzureKeyVaultName), cfg.GetString(cfgAzureKeyVaultPrefix))
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating Azure Key Vault kv store")
 		}

--- a/cmd/bank-vaults/main.go
+++ b/cmd/bank-vaults/main.go
@@ -76,7 +76,10 @@ const (
 	cfgAWS3SSEAlgo = "aws-s3-sse-algo"
 )
 
-const cfgAzureKeyVaultName = "azure-key-vault-name"
+const (
+	cfgAzureKeyVaultName   = "azure-key-vault-name"
+	cfgAzureKeyVaultPrefix = "azure-key-vault-prefix"
+)
 
 const (
 	cfgOciKeyOCID               = "oci-key-ocid"
@@ -244,6 +247,7 @@ func init() {
 
 	// Azure Key Vault flags
 	configStringVar(rootCmd, cfgAzureKeyVaultName, "", "The name of the Azure Key Vault to encrypt and store values in")
+	configStringVar(rootCmd, cfgAzureKeyVaultPrefix, "", "The prefix to use for secret names in Azure Key Vault")
 
 	// OCI Key flags
 	configStringVar(rootCmd, cfgOciKeyOCID, "", "The Oracle key OCID to use")

--- a/pkg/kv/azurekv/keyvault.go
+++ b/pkg/kv/azurekv/keyvault.go
@@ -43,6 +43,7 @@ const AzureAuthLocation = "AZURE_AUTH_LOCATION"
 // and decrypts and stores data using Azure Key Vault.
 type azureKeyVault struct {
 	client *azsecrets.Client
+	prefix string
 }
 
 type AuthConfig struct {
@@ -53,8 +54,10 @@ type AuthConfig struct {
 
 var _ kv.Service = &azureKeyVault{}
 
-// New creates a new kv.Service backed by Azure Key Vault
-func New(name string) (kv.Service, error) {
+// New creates a new kv.Service backed by Azure Key Vault.
+// The prefix is prepended to all secret names, allowing multiple
+// clients to share the same Key Vault without collisions.
+func New(name, prefix string) (kv.Service, error) {
 	if name == "" {
 		return nil, errors.Errorf("invalid Key Vault specified: '%s'", name)
 	}
@@ -72,11 +75,12 @@ func New(name string) (kv.Service, error) {
 
 	return &azureKeyVault{
 		client: client,
+		prefix: prefix,
 	}, nil
 }
 
 func (a *azureKeyVault) Get(ctx context.Context, key string) ([]byte, error) {
-	bundle, err := a.client.GetSecret(ctx, key, "", nil)
+	bundle, err := a.client.GetSecret(ctx, a.prefix+key, "", nil)
 	if err != nil {
 		var aerr *azcore.ResponseError
 		if errors.As(err, &aerr) && aerr.StatusCode == http.StatusNotFound {
@@ -91,7 +95,7 @@ func (a *azureKeyVault) Get(ctx context.Context, key string) ([]byte, error) {
 
 func (a *azureKeyVault) Set(ctx context.Context, key string, val []byte) error {
 	value := string(val)
-	_, err := a.client.SetSecret(ctx, key, azsecrets.SetSecretParameters{Value: &value}, nil)
+	_, err := a.client.SetSecret(ctx, a.prefix+key, azsecrets.SetSecretParameters{Value: &value}, nil)
 	return errors.Wrapf(err, "failed to set key: %s", key)
 }
 


### PR DESCRIPTION
## Overview

Add an optional `--azure-key-vault-prefix` flag that prepends a configurable string to all secret names stored in Azure Key Vault. This enables multiple independent consumers to share a single Key Vault instance without secret name collisions.

**Use case:** When running multiple Vault clusters that each store unseal/recovery keys in the same Azure Key Vault, the fixed secret names (`vault-recovery-0`, `vault-root`, etc.) collide. A prefix like `cluster-a-` produces `cluster-a-vault-recovery-0`, avoiding overwrites.

**Implementation:** Follows the exact pattern already used by the S3, GCS, OCI, and Alibaba OSS backends. The prefix is concatenated directly with the key name (no separator added automatically), giving users full control over the resulting secret name format.

When the prefix is empty (the default), behavior is identical to the current implementation.

### Changes

| File | Change |
|------|--------|
| `pkg/kv/azurekv/keyvault.go` | Add `prefix` field to struct, prepend in `Get`/`Set` |
| `cmd/bank-vaults/main.go` | Add `--azure-key-vault-prefix` CLI flag |
| `cmd/bank-vaults/common.go` | Pass prefix to `azurekv.New()` |

### Companion change needed

The [vault-operator](https://github.com/bank-vaults/vault-operator) `AzureUnsealConfig` struct will need a `keyPrefix` field and corresponding `--azure-key-vault-prefix` argument wiring. Happy to open that PR once this is reviewed.

## Notes for reviewer

- Azure Key Vault secret names only allow `[a-zA-Z0-9-]` (max 127 chars). Users are responsible for choosing a valid prefix. This matches how the S3 prefix works (no validation on the prefix value itself).
- No separator is injected between prefix and key, consistent with `objectNameWithPrefix` in the S3 and GCS backends.
- Default empty prefix means zero behavioral change for existing users.
