### PR TITLE
feat: configurable DNS suffix for the Azure Key Vault store

### DIFF
--- a/pkg/kv/azurekv/keyvault.go
+++ b/pkg/kv/azurekv/keyvault.go
@@ -39,6 +39,10 @@ import (
 
 const AzureAuthLocation = "AZURE_AUTH_LOCATION"
 
+const AzureKeyVaultDNSSuffix = "AZURE_KEYVAULT_DNS_SUFFIX"
+
+const defaultKeyVaultDNSSuffix = "vault.azure.net"
+
 // azureKeyVault is an implementation of the kv.Service interface, that encrypts
 // and decrypts and stores data using Azure Key Vault.
 type azureKeyVault struct {
@@ -67,8 +71,13 @@ func New(name, prefix string) (kv.Service, error) {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 
+	dnsSuffix := os.Getenv(AzureKeyVaultDNSSuffix)
+	if dnsSuffix == "" {
+		dnsSuffix = defaultKeyVaultDNSSuffix
+	}
+
 	// Establish a connection to the Key Vault client
-	client, err := azsecrets.NewClient(fmt.Sprintf("https://%s.%s", name, "vault.azure.net"), cred, nil)
+	client, err := azsecrets.NewClient(fmt.Sprintf("https://%s.%s", name, dnsSuffix), cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create Key Vault client: %v", err)
 	}


### PR DESCRIPTION
## Overview

The Azure KV store hardcodes the public cloud DNS suffix when building the vault URL, which breaks `azure-key-vault` unseal on Azure Government, Azure China and sovereign clouds.

This reads an optional `AZURE_KEYVAULT_DNS_SUFFIX` environment variable, defaulting to `vault.azure.net`, no behavior change for existing deployments. Credentials (IMDS) and token audience (auth challenge) already work on non-public clouds; the URL was the only hardcoded piece.

Fixes #3857

## Notes for reviewer

Verified on a sovereign Azure cloud (custom suffix, vault-operator `unsealConfig.azure`): the unsealer initializes and stores keys through the sovereign Key Vault.