### PR TITLE
feat: substitute auth mount accessor in allowed_uri_sans and allowed_other_sans

### DIFF
--- a/internal/vault/secrets_engines.go
+++ b/internal/vault/secrets_engines.go
@@ -49,8 +49,10 @@ var secretEnginesWithoutNameConfig = map[string]bool{
 
 // This object is used to easily find fields in secret engines that contain potentially templated expressions
 type secretEngineTemplatedConfig struct {
-	AllowedDomains []string               `mapstructure:"allowed_domains"`
-	Other          map[string]interface{} `mapstructure:",remain"`
+	AllowedDomains   []string               `mapstructure:"allowed_domains"`
+	AllowedUriSans   []string               `mapstructure:"allowed_uri_sans"`
+	AllowedOtherSans []string               `mapstructure:"allowed_other_sans"`
+	Other            map[string]interface{} `mapstructure:",remain"`
 }
 
 type secretEngine struct {
@@ -303,6 +305,24 @@ func (v *vault) addManagedSecretsEngines(ctx context.Context, managedSecretsEngi
 					pkiRole.AllowedDomains = templatedDomains
 					subConfigData = pkiRole.Other
 					subConfigData["allowed_domains"] = pkiRole.AllowedDomains
+
+					// Substitute auth mount accessors in URI and other SAN fields, mirroring allowed_domains.
+					// This allows PKI roles to use {{identity.entity.aliases.<accessor>.metadata.*}} templating
+					// in allowed_uri_sans / allowed_other_sans without hardcoding the generated accessor.
+					if len(pkiRole.AllowedUriSans) > 0 {
+						templatedUriSans := []string{}
+						for _, san := range pkiRole.AllowedUriSans {
+							templatedUriSans = append(templatedUriSans, replaceAccessor(san, mounts))
+						}
+						subConfigData["allowed_uri_sans"] = templatedUriSans
+					}
+					if len(pkiRole.AllowedOtherSans) > 0 {
+						templatedOtherSans := []string{}
+						for _, san := range pkiRole.AllowedOtherSans {
+							templatedOtherSans = append(templatedOtherSans, replaceAccessor(san, mounts))
+						}
+						subConfigData["allowed_other_sans"] = templatedOtherSans
+					}
 				} else {
 					// If the object could not be cast into a secretEngineTemplatedConfig,
 					// subConfigData will just be initialized from the subConfigDataRaw


### PR DESCRIPTION
## Overview

Extends the `secretEngineTemplatedConfig` accessor substitution (added in #3092 "templated policy support for PKI") to also cover `allowed_uri_sans` and `allowed_other_sans`, not just `allowed_domains`.

### Problem

The `secretEngineTemplatedConfig` struct only captured `allowed_domains`, so `replaceAccessor()` only resolved `__accessor__<path>` placeholders there. PKI roles that use `{{identity.entity.aliases.<accessor>.metadata.*}}` templating in `allowed_uri_sans` or `allowed_other_sans` had the placeholder written to Vault literally, breaking issuance at certificate-request time (Vault cannot resolve `{{identity.entity.aliases.__accessor__jwt/ticino.metadata.namespace}}` because `__accessor__jwt/ticino` is not a real accessor).

This blocks alias-metadata PKI roles that rely on URI SANs — notably SPIFFE SVID roles — from using the `${ accessor }` template function the way `allowed_domains`-only roles already can.

### Fix

Extend `secretEngineTemplatedConfig` to also capture `allowed_uri_sans` and `allowed_other_sans`, and run `replaceAccessor()` on them, mirroring the existing `allowed_domains` handling. This is additive: roles without these fields are untouched (guarded by `len() > 0` checks).

## Notes for reviewer

- Builds clean (`go build ./internal/vault/`)
- `replaceAccessor` is unchanged — it already works on any string; this PR just calls it on two more lists
- Ordering is unaffected: `configureAuthMethods()` still runs before `configureSecretsEngines()`, so auth mounts exist when accessors are resolved
- No test files exist in `internal/vault/` currently

### Use case unblocked

A SPIFFE SVID PKI role can now use:
```yaml
allowed_uri_sans:
  - "spiffe://example.com/kubernetes/{{identity.entity.aliases.__accessor__jwt/ticino.metadata.namespace}}/{{identity.entity.aliases.__accessor__jwt/ticino.metadata.service_account}}"
```
and bank-vaults resolves `__accessor__jwt/ticino` to the real accessor (e.g. `auth_jwt_5d027cb7`) at apply time, the same way it already does for `allowed_domains`.

## Checklist

- [x] Builds clean
- [x] Additive (no behavior change for roles without the new fields)
- [ ] Tests added (no test files in this package currently)
